### PR TITLE
Этап 2: инвентарь Стива + подбор предметов + просмотр

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -67,7 +67,7 @@
 | Этап | Содержание | Ключевые файлы |
 |------|-----------|----------------|
 | **1. Зрение** | Честный скан (raycast), целевой поиск, кэш, радиус в конфиге, сводка для промпта | WorldKnowledge, SteveConfig, PromptBuilder |
-| **2. Инвентарь** | 36 слотов + NBT, зачисление дропов, подбор ItemEntity, панель K + `/steve inventory` | SteveEntity, SteveGUI, SteveCommands, новое Inventory |
+| **2. Инвентарь** | 27 слотов (одинарный сундук; задел под апгрейды вместимости) + NBT, зачисление дропов, подбор ItemEntity, панель K + `/steve inventory`, ПКМ по боту — take-only меню | SteveEntity, SteveGUI, SteveCommands, SteveInventory, SteveMenu |
 | **3. Умный сбор** | Стратегия поверхность/руда, расширение поиска, инструменты, счёт по предметам, авто-возврат при полном инвентаре | MineBlockAction, GatherResourceAction, новое HarvestAction |
 | **4. Передача** | `give` (авто + команда), передача игроку, склад в сундуки | GiveAction, TaskPlanner (валидация), PromptBuilder |
 | **5. Мозги/диалог** | `respond`, `look`, обогащённый промпт, fallback-паттерны | PromptBuilder, ResponseParser, LLMFallbackHandler |

--- a/src/main/java/com/steve/ai/SteveMod.java
+++ b/src/main/java/com/steve/ai/SteveMod.java
@@ -5,6 +5,7 @@ import com.steve.ai.command.SteveCommands;
 import com.steve.ai.config.SteveConfig;
 import com.steve.ai.entity.SteveEntity;
 import com.steve.ai.entity.SteveManager;
+import com.steve.ai.network.SteveNetworking;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraftforge.common.MinecraftForge;
@@ -40,6 +41,8 @@ public class SteveMod {
 
     public SteveMod() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+        SteveNetworking.register();
 
         ENTITIES.register(modEventBus);
 

--- a/src/main/java/com/steve/ai/SteveMod.java
+++ b/src/main/java/com/steve/ai/SteveMod.java
@@ -5,6 +5,7 @@ import com.steve.ai.command.SteveCommands;
 import com.steve.ai.config.SteveConfig;
 import com.steve.ai.entity.SteveEntity;
 import com.steve.ai.entity.SteveManager;
+import com.steve.ai.menu.SteveMenus;
 import com.steve.ai.network.SteveNetworking;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
@@ -45,6 +46,7 @@ public class SteveMod {
         SteveNetworking.register();
 
         ENTITIES.register(modEventBus);
+        SteveMenus.MENUS.register(modEventBus);
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, SteveConfig.SPEC);
 

--- a/src/main/java/com/steve/ai/client/ClientSetup.java
+++ b/src/main/java/com/steve/ai/client/ClientSetup.java
@@ -1,6 +1,9 @@
 package com.steve.ai.client;
 
 import com.steve.ai.SteveMod;
+import com.steve.ai.entity.SteveEntity;
+import com.steve.ai.menu.SteveMenus;
+import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.model.geom.ModelLayers;
 import net.minecraft.client.renderer.entity.HumanoidMobRenderer;
@@ -11,7 +14,6 @@ import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import com.steve.ai.entity.SteveEntity;
 
 /**
  * Client-side setup for entity renderers and other client-only initialization
@@ -22,7 +24,10 @@ public class ClientSetup {
     private static final ResourceLocation STEVE_TEXTURE = new ResourceLocation("minecraft", "textures/entity/player/wide/steve.png");
 
     @SubscribeEvent
-    public static void onClientSetup(FMLClientSetupEvent event) {        event.enqueueWork(() -> {        });
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        event.enqueueWork(() -> {
+            MenuScreens.register(SteveMenus.STEVE_MENU.get(), SteveMenuScreen::new);
+        });
     }
 
     @SubscribeEvent

--- a/src/main/java/com/steve/ai/client/SteveGUI.java
+++ b/src/main/java/com/steve/ai/client/SteveGUI.java
@@ -373,7 +373,7 @@ public class SteveGUI {
 
         y += 4;
         String header = selectedSteve != null
-            ? "§e" + selectedSteve + "'s inventory§7 (" + inventoryStacks.size() + "/36 stacks)"
+            ? "§e" + selectedSteve + "'s inventory§7 (" + inventoryStacks.size() + " stacks)"
             : "§7No Steve selected";
         graphics.drawString(mc.font, header, panelX + PANEL_PADDING, y, TEXT_COLOR);
         y += 12;

--- a/src/main/java/com/steve/ai/client/SteveGUI.java
+++ b/src/main/java/com/steve/ai/client/SteveGUI.java
@@ -40,7 +40,6 @@ public class SteveGUI {
     private static List<String> steveNames = new ArrayList<>();
     private static String selectedSteve = null;
     private static List<ItemStack> inventoryStacks = new ArrayList<>();
-    private static long inventoryRequestedAt = 0;
 
     // Message history and scrolling
     private static List<ChatMessage> messages = new ArrayList<>();
@@ -188,7 +187,6 @@ public class SteveGUI {
     private static void requestInventory(String steveName) {
         Minecraft mc = Minecraft.getInstance();
         if (mc.player != null) {
-            inventoryRequestedAt = System.currentTimeMillis();
             SteveNetworking.CHANNEL.sendToServer(new ServerboundRequestInventoryPacket(steveName));
         }
     }
@@ -497,8 +495,9 @@ public class SteveGUI {
         int screenHeight = mc.getWindow().getGuiScaledHeight();
         int panelX = (int) (screenWidth - PANEL_WIDTH + slideOffset);
 
-        // Click on the header (title/tabs) toggles the view
-        if (mouseY < 35) {
+        // Click on the header (title/tabs) toggles the view - only within the
+        // panel's horizontal bounds (panelX..screenWidth), not anywhere on screen
+        if (mouseY < 35 && mouseX >= panelX && mouseX < screenWidth) {
             toggleView();
             return;
         }

--- a/src/main/java/com/steve/ai/client/SteveGUI.java
+++ b/src/main/java/com/steve/ai/client/SteveGUI.java
@@ -378,15 +378,15 @@ public class SteveGUI {
         graphics.drawString(mc.font, header, panelX + PANEL_PADDING, y, TEXT_COLOR);
         y += 12;
 
-        // Inventory grid: 9 columns x 4 rows
+        // Inventory grid: 9 columns x 3 rows (27 slots, matches the default capacity)
         int gridX = panelX + PANEL_PADDING + 2;
         int cols = 9;
         int index = 0;
         for (ItemStack stack : inventoryStacks) {
             int row = index / cols;
             int col = index % cols;
-            if (row >= 4) {
-                break; // Only render 36 slots
+            if (row >= 3) {
+                break; // Only render 27 slots
             }
             int slotX = gridX + col * SLOT_SIZE;
             int slotY = y + row * SLOT_SIZE;
@@ -397,7 +397,7 @@ public class SteveGUI {
             }
             index++;
         }
-        graphics.drawString(mc.font, "§8Items: " + totalItems(), panelX + PANEL_PADDING, y + 4 * SLOT_SIZE + 4, 0xFF777777);
+        graphics.drawString(mc.font, "§8Items: " + totalItems(), panelX + PANEL_PADDING, y + 3 * SLOT_SIZE + 4, 0xFF777777);
     }
 
     private static int totalItems() {

--- a/src/main/java/com/steve/ai/client/SteveGUI.java
+++ b/src/main/java/com/steve/ai/client/SteveGUI.java
@@ -3,10 +3,14 @@ package com.steve.ai.client;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.steve.ai.SteveMod;
 import com.steve.ai.entity.SteveEntity;
+import com.steve.ai.network.ServerboundRequestInventoryPacket;
+import com.steve.ai.network.ServerboundRequestSteveListPacket;
+import com.steve.ai.network.SteveNetworking;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -30,7 +34,14 @@ public class SteveGUI {
     private static EditBox inputBox;
     private static List<String> commandHistory = new ArrayList<>();
     private static int historyIndex = -1;
-    
+
+    // Inventory view state (client-side copies from server packets)
+    private static boolean showingInventory = false;
+    private static List<String> steveNames = new ArrayList<>();
+    private static String selectedSteve = null;
+    private static List<ItemStack> inventoryStacks = new ArrayList<>();
+    private static long inventoryRequestedAt = 0;
+
     // Message history and scrolling
     private static List<ChatMessage> messages = new ArrayList<>();
     private static int scrollOffset = 0;
@@ -39,6 +50,8 @@ public class SteveGUI {
     private static final int BORDER_COLOR = 0x40404040; // More transparent border
     private static final int HEADER_COLOR = 0x25252525; // More transparent header (~15% opacity)
     private static final int TEXT_COLOR = 0xFFFFFFFF;
+    private static final int SLOT_COLOR = 0x33FFFFFF;
+    private static final int SLOT_SIZE = 18;
     
     // Message bubble colors
     private static final int USER_BUBBLE_COLOR = 0xC04CAF50; // Green bubble for user
@@ -70,6 +83,7 @@ public class SteveGUI {
             if (inputBox != null) {
                 inputBox.setFocused(true);
             }
+            requestSteveList(); // Refresh Steve list so commands target real agents
         } else {
             if (inputBox != null) {
                 inputBox = null;
@@ -128,6 +142,57 @@ public class SteveGUI {
         addMessage("System", text, SYSTEM_BUBBLE_COLOR, false);
     }
 
+    /**
+     * Toggle between chat and inventory views.
+     */
+    public static void toggleView() {
+        showingInventory = !showingInventory;
+        if (showingInventory) {
+            requestSteveList();
+        }
+    }
+
+    public static boolean isShowingInventory() {
+        return showingInventory;
+    }
+
+    /**
+     * Called from the network handler: the list of active Steves.
+     */
+    public static void setSteveList(List<String> names) {
+        steveNames = new ArrayList<>(names);
+        if (selectedSteve == null || !steveNames.contains(selectedSteve)) {
+            selectedSteve = steveNames.isEmpty() ? null : steveNames.get(0);
+        }
+        if (selectedSteve != null) {
+            requestInventory(selectedSteve);
+        }
+    }
+
+    /**
+     * Called from the network handler: a Steve's inventory contents.
+     */
+    public static void setInventoryView(String steveName, List<ItemStack> stacks) {
+        if (steveName.equals(selectedSteve)) {
+            inventoryStacks = new ArrayList<>(stacks);
+        }
+    }
+
+    private static void requestSteveList() {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player != null) {
+            SteveNetworking.CHANNEL.sendToServer(new ServerboundRequestSteveListPacket());
+        }
+    }
+
+    private static void requestInventory(String steveName) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player != null) {
+            inventoryRequestedAt = System.currentTimeMillis();
+            SteveNetworking.CHANNEL.sendToServer(new ServerboundRequestInventoryPacket(steveName));
+        }
+    }
+
     @SubscribeEvent
     public static void onRenderOverlay(RenderGuiOverlayEvent.Post event) {
         if (event.getOverlay().id().toString().contains("hotbar")) {
@@ -168,8 +233,20 @@ public class SteveGUI {
 
         int headerHeight = 35;
         graphics.fillGradient(panelX, panelY, screenWidth, headerHeight, HEADER_COLOR, HEADER_COLOR);
-        graphics.drawString(mc.font, "§lSteve AI", panelX + PANEL_PADDING, panelY + 8, TEXT_COLOR);
-        graphics.drawString(mc.font, "§7ESC or Ctrl+K to close", panelX + PANEL_PADDING, panelY + 20, 0xFF888888);
+        graphics.drawString(mc.font, "§lSteve AI", panelX + PANEL_PADDING, panelY + 6, TEXT_COLOR);
+        // View tabs (clickable)
+        String chatTab = showingInventory ? "§7[Chat]" : "§e[Chat]";
+        String invTab = showingInventory ? "§e[Inv]" : "§7[Inv]";
+        graphics.drawString(mc.font, chatTab + " " + invTab, panelX + PANEL_PADDING + 58, panelY + 6, TEXT_COLOR);
+        graphics.drawString(mc.font, "§7ESC: close | Tab: view | Click name: select",
+            panelX + PANEL_PADDING, panelY + 20, 0xFF888888);
+
+        // Inventory view replaces the chat area entirely
+        if (showingInventory) {
+            renderInventoryView(graphics, mc, panelX, screenWidth, headerHeight);
+            RenderSystem.disableBlend();
+            return;
+        }
 
         // Message history area
         int inputAreaY = screenHeight - 80;
@@ -274,6 +351,66 @@ public class SteveGUI {
     }
 
     /**
+     * Renders the inventory view: a clickable list of Steves and the selected
+     * Steve's inventory grid.
+     */
+    private static void renderInventoryView(GuiGraphics graphics, Minecraft mc,
+                                            int panelX, int screenWidth, int headerHeight) {
+        int y = headerHeight + 10;
+
+        // Steve selector list
+        if (steveNames.isEmpty()) {
+            graphics.drawString(mc.font, "§7No Steves. Spawn one via chat:", panelX + PANEL_PADDING, y, 0xFFAAAAAA);
+            graphics.drawString(mc.font, "§7/steve spawn <name>", panelX + PANEL_PADDING, y + 12, 0xFFAAAAAA);
+            return;
+        }
+
+        graphics.drawString(mc.font, "§7Steves:", panelX + PANEL_PADDING, y, 0xFFAAAAAA);
+        y += 12;
+        for (String name : steveNames) {
+            String line = name.equals(selectedSteve) ? "§e> " + name : "§7  " + name;
+            graphics.drawString(mc.font, line, panelX + PANEL_PADDING, y, TEXT_COLOR);
+            y += 12;
+        }
+
+        y += 4;
+        String header = selectedSteve != null
+            ? "§e" + selectedSteve + "'s inventory§7 (" + inventoryStacks.size() + "/36 stacks)"
+            : "§7No Steve selected";
+        graphics.drawString(mc.font, header, panelX + PANEL_PADDING, y, TEXT_COLOR);
+        y += 12;
+
+        // Inventory grid: 9 columns x 4 rows
+        int gridX = panelX + PANEL_PADDING + 2;
+        int cols = 9;
+        int index = 0;
+        for (ItemStack stack : inventoryStacks) {
+            int row = index / cols;
+            int col = index % cols;
+            if (row >= 4) {
+                break; // Only render 36 slots
+            }
+            int slotX = gridX + col * SLOT_SIZE;
+            int slotY = y + row * SLOT_SIZE;
+            graphics.fill(slotX, slotY, slotX + SLOT_SIZE - 2, slotY + SLOT_SIZE - 2, SLOT_COLOR);
+            if (!stack.isEmpty()) {
+                graphics.renderItem(stack, slotX + 1, slotY + 1);
+                graphics.renderItemDecorations(mc.font, stack, slotX + 1, slotY + 1);
+            }
+            index++;
+        }
+        graphics.drawString(mc.font, "§8Items: " + totalItems(), panelX + PANEL_PADDING, y + 4 * SLOT_SIZE + 4, 0xFF777777);
+    }
+
+    private static int totalItems() {
+        int total = 0;
+        for (ItemStack stack : inventoryStacks) {
+            total += stack.getCount();
+        }
+        return total;
+    }
+
+    /**
      * Simple word wrap for text
      */
     private static String wrapText(net.minecraft.client.gui.Font font, String text, int maxWidth) {
@@ -296,6 +433,12 @@ public class SteveGUI {
 
         Minecraft mc = Minecraft.getInstance();
         
+        // Tab - toggle chat / inventory view
+        if (keyCode == 258) { // TAB
+            toggleView();
+            return true;
+        }
+
         // Enter key - send command
         if (keyCode == 257) {
             String command = inputBox.getValue().trim();
@@ -352,6 +495,30 @@ public class SteveGUI {
         Minecraft mc = Minecraft.getInstance();
         int screenWidth = mc.getWindow().getGuiScaledWidth();
         int screenHeight = mc.getWindow().getGuiScaledHeight();
+        int panelX = (int) (screenWidth - PANEL_WIDTH + slideOffset);
+
+        // Click on the header (title/tabs) toggles the view
+        if (mouseY < 35) {
+            toggleView();
+            return;
+        }
+
+        if (showingInventory) {
+            // Click on a Steve name selects it and requests its inventory
+            int y = 35 + 10 + 12; // headerHeight + 10 + "Steves:" label
+            for (String name : steveNames) {
+                if (mouseY >= y && mouseY < y + 12 && mouseX >= panelX && mouseX < panelX + PANEL_WIDTH) {
+                    if (!name.equals(selectedSteve)) {
+                        selectedSteve = name;
+                        inventoryStacks.clear();
+                        requestInventory(name);
+                    }
+                    return;
+                }
+                y += 12;
+            }
+            return;
+        }
 
         if (inputBox != null) {
             int inputAreaY = screenHeight - 80;
@@ -394,12 +561,12 @@ public class SteveGUI {
         List<String> targetSteves = parseTargetSteves(command);
         
         if (targetSteves.isEmpty()) {
-            var steves = SteveMod.getSteveManager().getAllSteves();
-            if (!steves.isEmpty()) {
-                targetSteves.add(steves.iterator().next().getSteveName());
+            if (!steveNames.isEmpty()) {
+                targetSteves.add(steveNames.get(0));
             } else {
-                // No Steves available
+                // No Steves available (client-side list; refresh from server)
                 addSystemMessage("No Steve agents found! Use 'spawn <name>' to create one.");
+                requestSteveList();
                 return;
             }
         }
@@ -424,17 +591,7 @@ public class SteveGUI {
         
         if (commandLower.startsWith("all steves ") || commandLower.startsWith("all ") || 
             commandLower.startsWith("everyone ") || commandLower.startsWith("everybody ")) {
-            var allSteves = SteveMod.getSteveManager().getAllSteves();
-            for (SteveEntity steve : allSteves) {
-                targets.add(steve.getSteveName());
-            }
-            return targets;
-        }
-        
-        var allSteves = SteveMod.getSteveManager().getAllSteves();
-        List<String> availableNames = new ArrayList<>();
-        for (SteveEntity steve : allSteves) {
-            availableNames.add(steve.getSteveName().toLowerCase());
+            return new ArrayList<>(steveNames);
         }
         
         String[] parts = command.split(",");
@@ -442,12 +599,10 @@ public class SteveGUI {
             String trimmed = part.trim();
             String firstWord = trimmed.split(" ")[0].toLowerCase();
             
-            if (availableNames.contains(firstWord)) {
-                for (SteveEntity steve : allSteves) {
-                    if (steve.getSteveName().equalsIgnoreCase(firstWord)) {
-                        targets.add(steve.getSteveName());
-                        break;
-                    }
+            for (String name : steveNames) {
+                if (name.toLowerCase().equals(firstWord)) {
+                    targets.add(name);
+                    break;
                 }
             }
         }

--- a/src/main/java/com/steve/ai/client/SteveMenuScreen.java
+++ b/src/main/java/com/steve/ai/client/SteveMenuScreen.java
@@ -10,41 +10,27 @@ import net.minecraft.world.entity.player.Inventory;
 /**
  * Screen for Steve's inventory menu.
  *
- * <p>Renders the vanilla single-chest background texture (generic_27) with a
- * stretched middle section so the 4-row container (36 slots) looks like a
- * regular chest - resource packs and container-styling mods that replace the
- * standard texture keep working. Slot rendering is handled by the base class.</p>
+ * <p>Uses the vanilla double-chest texture ({@code generic_54}) and the exact
+ * same blit as the vanilla {@code ChestScreen} double-chest rendering, so the
+ * menu looks like a regular large chest and resource packs / container
+ * styling mods that replace the standard texture keep working.</p>
  */
 public class SteveMenuScreen extends AbstractContainerScreen<SteveMenu> {
 
     private static final ResourceLocation CHEST_TEXTURE =
-        new ResourceLocation("textures/gui/container/generic_27.png");
-
-    /** Container rows = 4, so the panel is 186 px tall (chest texture is 168). */
-    private static final int PANEL_HEIGHT = 186;
+        new ResourceLocation("textures/gui/container/generic_54.png");
 
     public SteveMenuScreen(SteveMenu menu, Inventory playerInventory, Component title) {
         super(menu, playerInventory, title);
         this.imageWidth = 176;
-        this.imageHeight = PANEL_HEIGHT;
+        this.imageHeight = 222;
     }
 
     @Override
     protected void renderBg(GuiGraphics graphics, float partialTick, int mouseX, int mouseY) {
         int x = (this.width - this.imageWidth) / 2;
         int y = (this.height - this.imageHeight) / 2;
-
-        // Top strip (17 px, header with border)
-        graphics.blit(CHEST_TEXTURE, x, y, 0, 0, 176, 17, 176, 168);
-        // Middle section stretched from the texture's plain area (17..151)
-        graphics.blit(CHEST_TEXTURE, x, y + 17, 0, 17, 176, PANEL_HEIGHT - 34, 176, 134);
-        // Bottom strip (17 px, footer border)
-        graphics.blit(CHEST_TEXTURE, x, y + PANEL_HEIGHT - 17, 0, 151, 176, 17, 176, 168);
-    }
-
-    @Override
-    protected void renderLabels(GuiGraphics graphics, int mouseX, int mouseY) {
-        graphics.drawString(this.font, this.title, 8, 6, 4210752);
-        graphics.drawString(this.font, this.playerInventoryTitle, 8, this.imageHeight - 92, 4210752);
+        // Identical to ChestScreen's double-chest pass: whole texture, no slicing
+        graphics.blit(CHEST_TEXTURE, x, y, 0, 0, this.imageWidth, this.imageHeight);
     }
 }

--- a/src/main/java/com/steve/ai/client/SteveMenuScreen.java
+++ b/src/main/java/com/steve/ai/client/SteveMenuScreen.java
@@ -1,43 +1,50 @@
 package com.steve.ai.client;
 
-import com.steve.ai.SteveMod;
-import com.steve.ai.entity.SteveEntity;
 import com.steve.ai.menu.SteveMenu;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.phys.AABB;
 
 /**
- * Simple screen for Steve's inventory menu. No vanilla texture fits a
- * 4-row container, so the background is a plain translucent panel;
- * item icons and slot contents are rendered by the base class.
+ * Screen for Steve's inventory menu.
+ *
+ * <p>Renders the vanilla single-chest background texture (generic_27) with a
+ * stretched middle section so the 4-row container (36 slots) looks like a
+ * regular chest - resource packs and container-styling mods that replace the
+ * standard texture keep working. Slot rendering is handled by the base class.</p>
  */
 public class SteveMenuScreen extends AbstractContainerScreen<SteveMenu> {
+
+    private static final ResourceLocation CHEST_TEXTURE =
+        new ResourceLocation("textures/gui/container/generic_27.png");
+
+    /** Container rows = 4, so the panel is 186 px tall (chest texture is 168). */
+    private static final int PANEL_HEIGHT = 186;
 
     public SteveMenuScreen(SteveMenu menu, Inventory playerInventory, Component title) {
         super(menu, playerInventory, title);
         this.imageWidth = 176;
-        this.imageHeight = 184;
+        this.imageHeight = PANEL_HEIGHT;
     }
 
     @Override
     protected void renderBg(GuiGraphics graphics, float partialTick, int mouseX, int mouseY) {
         int x = (this.width - this.imageWidth) / 2;
         int y = (this.height - this.imageHeight) / 2;
-        // Panel background + header bar
-        graphics.fill(x, y, x + this.imageWidth, y + this.imageHeight, 0xC0121212);
-        graphics.fill(x, y, x + this.imageWidth, y + 17, 0xD03A3A3A);
-        // Separator line above the player inventory
-        graphics.fill(x, y + 93, x + this.imageWidth, y + 95, 0xFF3A3A3A);
+
+        // Top strip (17 px, header with border)
+        graphics.blit(CHEST_TEXTURE, x, y, 0, 0, 176, 17, 176, 168);
+        // Middle section stretched from the texture's plain area (17..151)
+        graphics.blit(CHEST_TEXTURE, x, y + 17, 0, 17, 176, PANEL_HEIGHT - 34, 176, 134);
+        // Bottom strip (17 px, footer border)
+        graphics.blit(CHEST_TEXTURE, x, y + PANEL_HEIGHT - 17, 0, 151, 176, 17, 176, 168);
     }
 
     @Override
     protected void renderLabels(GuiGraphics graphics, int mouseX, int mouseY) {
-        graphics.drawString(this.font, this.title, 8, 6, 0xFFFFFF);
-        graphics.drawString(this.font, this.playerInventoryTitle, 8, this.imageHeight - 92, 0xFFFFFF);
-        // Hint that Steve's slots are take-only
-        graphics.drawString(this.font, Component.literal("\u00a77take only"), 8, this.imageHeight - 102, 0xFFFFFF);
+        graphics.drawString(this.font, this.title, 8, 6, 4210752);
+        graphics.drawString(this.font, this.playerInventoryTitle, 8, this.imageHeight - 92, 4210752);
     }
 }

--- a/src/main/java/com/steve/ai/client/SteveMenuScreen.java
+++ b/src/main/java/com/steve/ai/client/SteveMenuScreen.java
@@ -1,0 +1,43 @@
+package com.steve.ai.client;
+
+import com.steve.ai.SteveMod;
+import com.steve.ai.entity.SteveEntity;
+import com.steve.ai.menu.SteveMenu;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.phys.AABB;
+
+/**
+ * Simple screen for Steve's inventory menu. No vanilla texture fits a
+ * 4-row container, so the background is a plain translucent panel;
+ * item icons and slot contents are rendered by the base class.
+ */
+public class SteveMenuScreen extends AbstractContainerScreen<SteveMenu> {
+
+    public SteveMenuScreen(SteveMenu menu, Inventory playerInventory, Component title) {
+        super(menu, playerInventory, title);
+        this.imageWidth = 176;
+        this.imageHeight = 184;
+    }
+
+    @Override
+    protected void renderBg(GuiGraphics graphics, float partialTick, int mouseX, int mouseY) {
+        int x = (this.width - this.imageWidth) / 2;
+        int y = (this.height - this.imageHeight) / 2;
+        // Panel background + header bar
+        graphics.fill(x, y, x + this.imageWidth, y + this.imageHeight, 0xC0121212);
+        graphics.fill(x, y, x + this.imageWidth, y + 17, 0xD03A3A3A);
+        // Separator line above the player inventory
+        graphics.fill(x, y + 93, x + this.imageWidth, y + 95, 0xFF3A3A3A);
+    }
+
+    @Override
+    protected void renderLabels(GuiGraphics graphics, int mouseX, int mouseY) {
+        graphics.drawString(this.font, this.title, 8, 6, 0xFFFFFF);
+        graphics.drawString(this.font, this.playerInventoryTitle, 8, this.imageHeight - 92, 0xFFFFFF);
+        // Hint that Steve's slots are take-only
+        graphics.drawString(this.font, Component.literal("\u00a77take only"), 8, this.imageHeight - 102, 0xFFFFFF);
+    }
+}

--- a/src/main/java/com/steve/ai/client/SteveMenuScreen.java
+++ b/src/main/java/com/steve/ai/client/SteveMenuScreen.java
@@ -10,10 +10,11 @@ import net.minecraft.world.entity.player.Inventory;
 /**
  * Screen for Steve's inventory menu.
  *
- * <p>Uses the vanilla double-chest texture ({@code generic_54}) and the exact
- * same blit as the vanilla {@code ChestScreen} double-chest rendering, so the
- * menu looks like a regular large chest and resource packs / container
- * styling mods that replace the standard texture keep working.</p>
+ * <p>Renders exactly like a vanilla single chest: the {@code generic_54}
+ * texture is blitted with the same two slices the vanilla {@code ChestScreen}
+ * uses for single chests (upper 71px + lower 96px at texture y=126). Resource
+ * packs / container styling mods that replace the standard texture keep
+ * working.</p>
  */
 public class SteveMenuScreen extends AbstractContainerScreen<SteveMenu> {
 
@@ -23,14 +24,15 @@ public class SteveMenuScreen extends AbstractContainerScreen<SteveMenu> {
     public SteveMenuScreen(SteveMenu menu, Inventory playerInventory, Component title) {
         super(menu, playerInventory, title);
         this.imageWidth = 176;
-        this.imageHeight = 222;
+        this.imageHeight = 168;
     }
 
     @Override
     protected void renderBg(GuiGraphics graphics, float partialTick, int mouseX, int mouseY) {
         int x = (this.width - this.imageWidth) / 2;
         int y = (this.height - this.imageHeight) / 2;
-        // Identical to ChestScreen's double-chest pass: whole texture, no slicing
-        graphics.blit(CHEST_TEXTURE, x, y, 0, 0, this.imageWidth, this.imageHeight);
+        // Vanilla single-chest slices: upper (0..71) + lower (texture y 126..222)
+        graphics.blit(CHEST_TEXTURE, x, y, 0, 0, this.imageWidth, 71);
+        graphics.blit(CHEST_TEXTURE, x, y + 71, 0, 126, this.imageWidth, 96);
     }
 }

--- a/src/main/java/com/steve/ai/command/SteveCommands.java
+++ b/src/main/java/com/steve/ai/command/SteveCommands.java
@@ -7,6 +7,7 @@ import com.steve.ai.SteveMod;
 import com.steve.ai.config.SteveConfig;
 import com.steve.ai.debug.AgentDebugBuffer;
 import com.steve.ai.entity.SteveEntity;
+import com.steve.ai.entity.SteveInventory;
 import com.steve.ai.entity.SteveManager;
 import com.steve.ai.llm.LLMProviders;
 import com.steve.ai.llm.async.OpenAICompatibleClient;
@@ -41,7 +42,28 @@ public class SteveCommands {
                 .executes(SteveCommands::listProviders))
             .then(Commands.literal("debug")
                 .executes(SteveCommands::debugSteve))
+            .then(Commands.literal("inventory")
+                .then(Commands.argument("name", StringArgumentType.string())
+                    .executes(SteveCommands::showInventory)))
         );
+    }
+
+    private static int showInventory(CommandContext<CommandSourceStack> context) {
+        String name = StringArgumentType.getString(context, "name");
+        CommandSourceStack source = context.getSource();
+
+        SteveEntity steve = SteveMod.getSteveManager().getSteve(name);
+        if (steve == null) {
+            source.sendFailure(Component.literal("Steve not found: " + name));
+            return 0;
+        }
+
+        SteveInventory inventory = steve.getInventory();
+        source.sendSuccess(() -> Component.literal(
+            "§e" + name + "'s inventory§7 (" + inventory.getStacksCount() + "/" + inventory.getMaxSize()
+                + " stacks, " + inventory.getTotalCount() + " items): " + inventory.toDisplayString()),
+            false);
+        return 1;
     }
 
     private static int debugSteve(CommandContext<CommandSourceStack> context) {

--- a/src/main/java/com/steve/ai/entity/SteveEntity.java
+++ b/src/main/java/com/steve/ai/entity/SteveEntity.java
@@ -7,7 +7,11 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -15,7 +19,10 @@ import net.minecraft.world.entity.ai.goal.FloatGoal;
 import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.world.entity.ai.goal.RandomLookAroundGoal;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
@@ -208,6 +215,21 @@ public class SteveEntity extends PathfinderMob {
         
         Component chatComponent = Component.literal("<" + this.steveName + "> " + message);
         this.level().players().forEach(player -> player.sendSystemMessage(chatComponent));
+    }
+
+    /**
+     * Right-click on a Steve opens its inventory as a vanilla chest menu:
+     * the player can selectively take items (and give items back).
+     */
+    @Override
+    public InteractionResult mobInteract(Player player, InteractionHand hand) {
+        if (!this.level().isClientSide && player instanceof ServerPlayer serverPlayer) {
+            serverPlayer.openMenu(new SimpleMenuProvider(
+                (containerId, playerInventory, p) -> new ChestMenu(
+                    MenuType.GENERIC_9x4, containerId, playerInventory, this.inventory, 4),
+                Component.literal(this.steveName + "'s Inventory")));
+        }
+        return InteractionResult.sidedSuccess(this.level().isClientSide);
     }
 
     @Override

--- a/src/main/java/com/steve/ai/entity/SteveEntity.java
+++ b/src/main/java/com/steve/ai/entity/SteveEntity.java
@@ -2,6 +2,7 @@ package com.steve.ai.entity;
 
 import com.steve.ai.action.ActionExecutor;
 import com.steve.ai.memory.SteveMemory;
+import com.steve.ai.menu.SteveMenu;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -19,10 +20,7 @@ import net.minecraft.world.entity.ai.goal.FloatGoal;
 import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.world.entity.ai.goal.RandomLookAroundGoal;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.ChestMenu;
-import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
@@ -54,7 +52,7 @@ public class SteveEntity extends PathfinderMob {
         this.steveName = "Steve";
         this.memory = new SteveMemory(this);
         this.actionExecutor = new ActionExecutor(this);
-        this.inventory = new SteveInventory();
+        this.inventory = new SteveInventory(this, SteveInventory.DEFAULT_SIZE);
         this.setCustomNameVisible(true);
         
         this.isInvulnerable = true;
@@ -218,15 +216,15 @@ public class SteveEntity extends PathfinderMob {
     }
 
     /**
-     * Right-click on a Steve opens its inventory as a vanilla chest menu:
-     * the player can selectively take items (and give items back).
+     * Right-click on a Steve opens its inventory as a take-only container menu:
+     * the player can selectively take items, but cannot place items into Steve.
      */
     @Override
     public InteractionResult mobInteract(Player player, InteractionHand hand) {
         if (!this.level().isClientSide && player instanceof ServerPlayer serverPlayer) {
             serverPlayer.openMenu(new SimpleMenuProvider(
-                (containerId, playerInventory, p) -> new ChestMenu(
-                    MenuType.GENERIC_9x4, containerId, playerInventory, this.inventory, 4),
+                (containerId, playerInventory, p) ->
+                    new SteveMenu(containerId, playerInventory, this.inventory),
                 Component.literal(this.steveName + "'s Inventory")));
         }
         return InteractionResult.sidedSuccess(this.level().isClientSide);

--- a/src/main/java/com/steve/ai/entity/SteveEntity.java
+++ b/src/main/java/com/steve/ai/entity/SteveEntity.java
@@ -76,6 +76,20 @@ public class SteveEntity extends PathfinderMob {
     }
 
     @Override
+    public void remove(RemovalReason reason) {
+        // Drop the inventory into the world when Steve is killed or discarded
+        // (/kill, /steve remove) instead of silently losing the contents.
+        // Unloading/changing dimension must keep the inventory (it is in NBT).
+        if (!this.level().isClientSide && !inventory.isEmpty()
+                && (reason == RemovalReason.KILLED || reason == RemovalReason.DISCARDED)) {
+            for (ItemStack stack : inventory.takeAll()) {
+                this.spawnAtLocation(stack);
+            }
+        }
+        super.remove(reason);
+    }
+
+    @Override
     public void tick() {
         super.tick();
         
@@ -102,6 +116,11 @@ public class SteveEntity extends PathfinderMob {
         List<ItemEntity> items = this.level().getEntitiesOfClass(ItemEntity.class, searchBox);
         for (ItemEntity item : items) {
             if (item.isRemoved() || !item.isAlive()) {
+                continue;
+            }
+            // Respect vanilla pickup delay: items thrown by a player (Q), tossed
+            // to teammates or dropped on death must not be vacuumed instantly
+            if (item.hasPickUpDelay()) {
                 continue;
             }
             ItemStack stack = item.getItem();

--- a/src/main/java/com/steve/ai/entity/SteveEntity.java
+++ b/src/main/java/com/steve/ai/entity/SteveEntity.java
@@ -14,10 +14,15 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.FloatGoal;
 import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.world.entity.ai.goal.RandomLookAroundGoal;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class SteveEntity extends PathfinderMob {
     private static final EntityDataAccessor<String> STEVE_NAME = 
@@ -26,15 +31,23 @@ public class SteveEntity extends PathfinderMob {
     private String steveName;
     private SteveMemory memory;
     private ActionExecutor actionExecutor;
+    private SteveInventory inventory;
     private int tickCounter = 0;
+    private int pickupCooldown = 0;
     private boolean isFlying = false;
     private boolean isInvulnerable = false;
+
+    /** Pickup radius for items lying on the ground, in blocks. */
+    private static final double PICKUP_RADIUS = 3.0;
+    /** Pickup scan every N ticks (20 ticks = 1 second). */
+    private static final int PICKUP_INTERVAL = 10;
 
     public SteveEntity(EntityType<? extends PathfinderMob> entityType, Level level) {
         super(entityType, level);
         this.steveName = "Steve";
         this.memory = new SteveMemory(this);
         this.actionExecutor = new ActionExecutor(this);
+        this.inventory = new SteveInventory();
         this.setCustomNameVisible(true);
         
         this.isInvulnerable = true;
@@ -68,6 +81,45 @@ public class SteveEntity extends PathfinderMob {
         
         if (!this.level().isClientSide) {
             actionExecutor.tick();
+            tickPickup();
+        }
+    }
+
+    /**
+     * Periodically picks up nearby item entities into Steve's inventory.
+     */
+    private void tickPickup() {
+        if (--pickupCooldown > 0) {
+            return;
+        }
+        pickupCooldown = PICKUP_INTERVAL;
+
+        if (!inventory.hasFreeSpace()) {
+            return; // Inventory full - leave items on the ground
+        }
+
+        AABB searchBox = this.getBoundingBox().inflate(PICKUP_RADIUS);
+        List<ItemEntity> items = this.level().getEntitiesOfClass(ItemEntity.class, searchBox);
+        for (ItemEntity item : items) {
+            if (item.isRemoved() || !item.isAlive()) {
+                continue;
+            }
+            ItemStack stack = item.getItem();
+            if (stack.isEmpty()) {
+                continue;
+            }
+            ItemStack remainder = inventory.addItem(stack);
+            if (remainder.getCount() < stack.getCount()) {
+                // We picked up at least part of the stack
+                if (remainder.isEmpty()) {
+                    item.discard();
+                } else {
+                    item.setItem(remainder);
+                }
+            }
+            if (!inventory.hasFreeSpace()) {
+                break; // Inventory full - stop picking up
+            }
         }
     }
 
@@ -85,6 +137,10 @@ public class SteveEntity extends PathfinderMob {
         return this.memory;
     }
 
+    public SteveInventory getInventory() {
+        return this.inventory;
+    }
+
     public ActionExecutor getActionExecutor() {
         return this.actionExecutor;
     }
@@ -97,6 +153,10 @@ public class SteveEntity extends PathfinderMob {
         CompoundTag memoryTag = new CompoundTag();
         this.memory.saveToNBT(memoryTag);
         tag.put("Memory", memoryTag);
+
+        CompoundTag inventoryTag = new CompoundTag();
+        this.inventory.saveToNBT(inventoryTag);
+        tag.put("Inventory", inventoryTag);
     }
 
     @Override
@@ -108,6 +168,10 @@ public class SteveEntity extends PathfinderMob {
         
         if (tag.contains("Memory")) {
             this.memory.loadFromNBT(tag.getCompound("Memory"));
+        }
+
+        if (tag.contains("Inventory")) {
+            this.inventory.loadFromNBT(tag.getCompound("Inventory"));
         }
     }
 

--- a/src/main/java/com/steve/ai/entity/SteveInventory.java
+++ b/src/main/java/com/steve/ai/entity/SteveInventory.java
@@ -14,8 +14,8 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Steve's inventory: a fixed array of slots (default 36, matching a player's
- * main inventory) with NBT persistence.
+ * Steve's inventory: a fixed array of slots (default 27, matching a vanilla
+ * single chest / the player's main grid) with NBT persistence.
  *
  * <p>Slot indices are stable ({@link ItemStack#EMPTY} fills empty slots), which
  * is required for the vanilla container menu contract: the menu addresses each

--- a/src/main/java/com/steve/ai/entity/SteveInventory.java
+++ b/src/main/java/com/steve/ai/entity/SteveInventory.java
@@ -1,0 +1,170 @@
+package com.steve.ai.entity;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Steve's inventory: a fixed-size list of ItemStacks (default 36 slots,
+ * matching a player's main inventory) with NBT persistence.
+ *
+ * <p>ItemStacks are stored as full stacks (they merge on add, no slot-based
+ * layout yet - that keeps the logic simple and the data compact).</p>
+ */
+public class SteveInventory {
+
+    public static final int DEFAULT_SIZE = 36;
+    private static final String NBT_KEY = "Inventory";
+    private static final String NBT_SIZE = "Size";
+
+    private final List<ItemStack> stacks;
+    private final int maxSize;
+
+    public SteveInventory() {
+        this(DEFAULT_SIZE);
+    }
+
+    public SteveInventory(int maxSize) {
+        this.maxSize = maxSize;
+        this.stacks = new ArrayList<>();
+    }
+
+    /**
+     * Attempts to add the given stack (or part of it) to the inventory.
+     * Returns what could NOT be stored (empty stack if everything fit).
+     */
+    public ItemStack addItem(ItemStack incoming) {
+        if (incoming.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        ItemStack remainder = incoming.copy();
+
+        // Merge into existing stacks of the same item first
+        for (ItemStack stack : stacks) {
+            if (remainder.isEmpty()) {
+                return ItemStack.EMPTY;
+            }
+            if (ItemStack.isSameItemSameTags(stack, remainder)) {
+                int space = stack.getMaxStackSize() - stack.getCount();
+                if (space > 0) {
+                    int move = Math.min(space, remainder.getCount());
+                    stack.grow(move);
+                    remainder.shrink(move);
+                }
+            }
+        }
+
+        // Open new stacks while there is room
+        while (!remainder.isEmpty() && stacks.size() < maxSize) {
+            int perStack = Math.min(remainder.getCount(), remainder.getMaxStackSize());
+            ItemStack newStack = remainder.copy();
+            newStack.setCount(perStack);
+            stacks.add(newStack);
+            remainder.shrink(perStack);
+        }
+
+        return remainder;
+    }
+
+    /**
+     * Whether the inventory can hold at least one more item.
+     */
+    public boolean hasFreeSpace() {
+        if (stacks.size() < maxSize) {
+            return true;
+        }
+        for (ItemStack stack : stacks) {
+            if (stack.getCount() < stack.getMaxStackSize()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isEmpty() {
+        return stacks.isEmpty();
+    }
+
+    /**
+     * Total count of items of the given type across all stacks.
+     */
+    public int countItem(Item item) {
+        int total = 0;
+        for (ItemStack stack : stacks) {
+            if (stack.is(item)) {
+                total += stack.getCount();
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Total number of items across all stacks.
+     */
+    public int getTotalCount() {
+        int total = 0;
+        for (ItemStack stack : stacks) {
+            total += stack.getCount();
+        }
+        return total;
+    }
+
+    public int getStacksCount() {
+        return stacks.size();
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public List<ItemStack> getStacks() {
+        return stacks;
+    }
+
+    /**
+     * Removes and returns everything (used for handing items over to a player).
+     */
+    public List<ItemStack> takeAll() {
+        List<ItemStack> taken = new ArrayList<>(stacks);
+        stacks.clear();
+        return taken;
+    }
+
+    public void saveToNBT(CompoundTag tag) {
+        ListTag list = new ListTag();
+        for (ItemStack stack : stacks) {
+            list.add(stack.save(new CompoundTag()));
+        }
+        tag.put(NBT_KEY, list);
+        tag.putInt(NBT_SIZE, maxSize);
+    }
+
+    public void loadFromNBT(CompoundTag tag) {
+        stacks.clear();
+        ListTag list = tag.getList(NBT_KEY, Tag.TAG_COMPOUND);
+        for (int i = 0; i < list.size(); i++) {
+            ItemStack stack = ItemStack.of(list.getCompound(i));
+            if (!stack.isEmpty()) {
+                stacks.add(stack);
+            }
+        }
+    }
+
+    public String toDisplayString() {
+        if (stacks.isEmpty()) {
+            return "empty";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (ItemStack stack : stacks) {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append(stack.getHoverName().getString()).append(" x").append(stack.getCount());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/steve/ai/entity/SteveInventory.java
+++ b/src/main/java/com/steve/ai/entity/SteveInventory.java
@@ -3,6 +3,8 @@ package com.steve.ai.entity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
@@ -16,8 +18,11 @@ import java.util.List;
  *
  * <p>ItemStacks are stored as full stacks (they merge on add, no slot-based
  * layout yet - that keeps the logic simple and the data compact).</p>
+ *
+ * <p>Implements {@link Container} so players can open Steve's inventory via
+ * a vanilla chest menu (right-click on Steve) and take/give items selectively.</p>
  */
-public class SteveInventory {
+public class SteveInventory implements Container {
 
     public static final int DEFAULT_SIZE = 36;
     private static final String NBT_KEY = "Inventory";
@@ -173,5 +178,81 @@ public class SteveInventory {
             sb.append(stack.getHoverName().getString()).append(" x").append(stack.getCount());
         }
         return sb.toString();
+    }
+
+    // ==================== Container implementation ====================
+    // Slot-based access for the vanilla chest menu (right-click on Steve).
+    // A "slot" is an index into the compact stack list; empty slots beyond the
+    // list read as ItemStack.EMPTY, and removing an item shrinks the list.
+
+    @Override
+    public int getContainerSize() {
+        return maxSize;
+    }
+
+    @Override
+    public ItemStack getItem(int slot) {
+        return slot >= 0 && slot < stacks.size() ? stacks.get(slot) : ItemStack.EMPTY;
+    }
+
+    @Override
+    public ItemStack removeItem(int slot, int amount) {
+        if (slot < 0 || slot >= stacks.size()) {
+            return ItemStack.EMPTY;
+        }
+        ItemStack stack = stacks.get(slot);
+        if (stack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+        int toRemove = Math.min(amount, stack.getCount());
+        ItemStack removed = stack.copy();
+        removed.setCount(toRemove);
+        stack.shrink(toRemove);
+        if (stack.isEmpty()) {
+            stacks.remove(slot);
+        }
+        return removed;
+    }
+
+    @Override
+    public ItemStack removeItemNoUpdate(int slot) {
+        if (slot < 0 || slot >= stacks.size()) {
+            return ItemStack.EMPTY;
+        }
+        return stacks.remove(slot);
+    }
+
+    @Override
+    public void setItem(int slot, ItemStack stack) {
+        if (slot < 0 || slot >= maxSize) {
+            return;
+        }
+        if (stack.isEmpty()) {
+            if (slot < stacks.size()) {
+                stacks.remove(slot);
+            }
+            return;
+        }
+        if (slot < stacks.size()) {
+            stacks.set(slot, stack);
+        } else if (slot == stacks.size() && stacks.size() < maxSize) {
+            stacks.add(stack);
+        }
+        // slot > size: ignore (client only sends valid slot operations)
+    }
+
+    @Override
+    public void setChanged() {
+        // No-op: SteveInventory is not a block entity
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+
+    @Override
+    public void clearContent() {
+        stacks.clear();
     }
 }

--- a/src/main/java/com/steve/ai/entity/SteveInventory.java
+++ b/src/main/java/com/steve/ai/entity/SteveInventory.java
@@ -9,34 +9,45 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 /**
- * Steve's inventory: a fixed-size list of ItemStacks (default 36 slots,
- * matching a player's main inventory) with NBT persistence.
+ * Steve's inventory: a fixed array of slots (default 36, matching a player's
+ * main inventory) with NBT persistence.
  *
- * <p>ItemStacks are stored as full stacks (they merge on add, no slot-based
- * layout yet - that keeps the logic simple and the data compact).</p>
+ * <p>Slot indices are stable ({@link ItemStack#EMPTY} fills empty slots), which
+ * is required for the vanilla container menu contract: the menu addresses each
+ * of the 36 slots by index, and any placement into an empty slot must be
+ * stored, never dropped.</p>
  *
- * <p>Implements {@link Container} so players can open Steve's inventory via
- * a vanilla chest menu (right-click on Steve) and take/give items selectively.</p>
+ * <p>Implements {@link Container} so players can open Steve's inventory via a
+ * container menu (right-click on Steve) and selectively take items.</p>
  */
 public class SteveInventory implements Container {
 
     public static final int DEFAULT_SIZE = 36;
     private static final String NBT_KEY = "Inventory";
 
-    private final List<ItemStack> stacks;
+    private final ItemStack[] slots;
     private final int maxSize;
+    /** Owner for stillValid() checks; null in unit tests. */
+    private final SteveEntity owner;
 
     public SteveInventory() {
-        this(DEFAULT_SIZE);
+        this(null, DEFAULT_SIZE);
     }
 
     public SteveInventory(int maxSize) {
+        this(null, maxSize);
+    }
+
+    public SteveInventory(SteveEntity owner, int maxSize) {
+        this.owner = owner;
         this.maxSize = maxSize;
-        this.stacks = new ArrayList<>();
+        this.slots = new ItemStack[maxSize];
+        Arrays.fill(slots, ItemStack.EMPTY);
     }
 
     /**
@@ -50,28 +61,28 @@ public class SteveInventory implements Container {
 
         ItemStack remainder = incoming.copy();
 
-        // Merge into existing stacks of the same item first
-        for (ItemStack stack : stacks) {
-            if (remainder.isEmpty()) {
-                return ItemStack.EMPTY;
-            }
-            if (ItemStack.isSameItemSameTags(stack, remainder)) {
-                int space = stack.getMaxStackSize() - stack.getCount();
+        // Merge into existing non-full stacks of the same item
+        for (int i = 0; i < maxSize && !remainder.isEmpty(); i++) {
+            ItemStack slot = slots[i];
+            if (!slot.isEmpty() && ItemStack.isSameItemSameTags(slot, remainder)) {
+                int space = slot.getMaxStackSize() - slot.getCount();
                 if (space > 0) {
                     int move = Math.min(space, remainder.getCount());
-                    stack.grow(move);
+                    slot.grow(move);
                     remainder.shrink(move);
                 }
             }
         }
 
-        // Open new stacks while there is room
-        while (!remainder.isEmpty() && stacks.size() < maxSize) {
-            int perStack = Math.min(remainder.getCount(), remainder.getMaxStackSize());
-            ItemStack newStack = remainder.copy();
-            newStack.setCount(perStack);
-            stacks.add(newStack);
-            remainder.shrink(perStack);
+        // Place into the first empty slot
+        for (int i = 0; i < maxSize && !remainder.isEmpty(); i++) {
+            if (slots[i].isEmpty()) {
+                int perStack = Math.min(remainder.getCount(), remainder.getMaxStackSize());
+                ItemStack newStack = remainder.copy();
+                newStack.setCount(perStack);
+                slots[i] = newStack;
+                remainder.shrink(perStack);
+            }
         }
 
         return remainder;
@@ -81,47 +92,64 @@ public class SteveInventory implements Container {
      * Whether the inventory can hold at least one more item.
      */
     public boolean hasFreeSpace() {
-        if (stacks.size() < maxSize) {
-            return true;
-        }
-        for (ItemStack stack : stacks) {
-            if (stack.getCount() < stack.getMaxStackSize()) {
+        for (int i = 0; i < maxSize; i++) {
+            if (slots[i].isEmpty()) {
+                return true;
+            }
+            if (slots[i].getCount() < slots[i].getMaxStackSize()) {
                 return true;
             }
         }
         return false;
     }
 
+    @Override
     public boolean isEmpty() {
-        return stacks.isEmpty();
+        for (ItemStack slot : slots) {
+            if (!slot.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
-     * Total count of items of the given type across all stacks.
+     * Total count of items of the given type across all slots.
      */
     public int countItem(Item item) {
         int total = 0;
-        for (ItemStack stack : stacks) {
-            if (stack.is(item)) {
-                total += stack.getCount();
+        for (ItemStack slot : slots) {
+            if (!slot.isEmpty() && slot.is(item)) {
+                total += slot.getCount();
             }
         }
         return total;
     }
 
     /**
-     * Total number of items across all stacks.
+     * Total number of items across all slots.
      */
     public int getTotalCount() {
         int total = 0;
-        for (ItemStack stack : stacks) {
-            total += stack.getCount();
+        for (ItemStack slot : slots) {
+            if (!slot.isEmpty()) {
+                total += slot.getCount();
+            }
         }
         return total;
     }
 
+    /**
+     * Number of non-empty slots.
+     */
     public int getStacksCount() {
-        return stacks.size();
+        int count = 0;
+        for (ItemStack slot : slots) {
+            if (!slot.isEmpty()) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public int getMaxSize() {
@@ -129,51 +157,60 @@ public class SteveInventory implements Container {
     }
 
     /**
-     * Read-only view of the stacks. Mutate only through the inventory methods.
+     * Read-only view of the non-empty stacks, in slot order.
      */
     public List<ItemStack> getStacks() {
-        return Collections.unmodifiableList(stacks);
+        List<ItemStack> nonEmpty = new ArrayList<>();
+        for (ItemStack slot : slots) {
+            if (!slot.isEmpty()) {
+                nonEmpty.add(slot);
+            }
+        }
+        return Collections.unmodifiableList(nonEmpty);
     }
 
     /**
      * Removes and returns everything (used for handing items over to a player).
      */
     public List<ItemStack> takeAll() {
-        List<ItemStack> taken = new ArrayList<>(stacks);
-        stacks.clear();
+        List<ItemStack> taken = new ArrayList<>();
+        for (int i = 0; i < maxSize; i++) {
+            if (!slots[i].isEmpty()) {
+                taken.add(slots[i]);
+                slots[i] = ItemStack.EMPTY;
+            }
+        }
         return taken;
     }
 
     public void saveToNBT(CompoundTag tag) {
         ListTag list = new ListTag();
-        for (ItemStack stack : stacks) {
-            list.add(stack.save(new CompoundTag()));
+        for (ItemStack slot : slots) {
+            if (!slot.isEmpty()) {
+                list.add(slot.save(new CompoundTag()));
+            }
         }
         tag.put(NBT_KEY, list);
     }
 
     public void loadFromNBT(CompoundTag tag) {
-        stacks.clear();
+        Arrays.fill(slots, ItemStack.EMPTY);
         ListTag list = tag.getList(NBT_KEY, Tag.TAG_COMPOUND);
-        for (int i = 0; i < list.size(); i++) {
-            // Preserve the invariant stacks.size() <= maxSize even if the NBT
-            // holds more entries than the configured capacity
-            if (stacks.size() >= maxSize) {
-                break;
-            }
+        int slotIndex = 0;
+        for (int i = 0; i < list.size() && slotIndex < maxSize; i++) {
             ItemStack stack = ItemStack.of(list.getCompound(i));
             if (!stack.isEmpty()) {
-                stacks.add(stack);
+                slots[slotIndex++] = stack;
             }
         }
     }
 
     public String toDisplayString() {
-        if (stacks.isEmpty()) {
+        if (isEmpty()) {
             return "empty";
         }
         StringBuilder sb = new StringBuilder();
-        for (ItemStack stack : stacks) {
+        for (ItemStack stack : getStacks()) {
             if (sb.length() > 0) sb.append(", ");
             sb.append(stack.getHoverName().getString()).append(" x").append(stack.getCount());
         }
@@ -181,9 +218,7 @@ public class SteveInventory implements Container {
     }
 
     // ==================== Container implementation ====================
-    // Slot-based access for the vanilla chest menu (right-click on Steve).
-    // A "slot" is an index into the compact stack list; empty slots beyond the
-    // list read as ItemStack.EMPTY, and removing an item shrinks the list.
+    // Fixed slot model: indices are stable, empty slots are ItemStack.EMPTY.
 
     @Override
     public int getContainerSize() {
@@ -192,34 +227,33 @@ public class SteveInventory implements Container {
 
     @Override
     public ItemStack getItem(int slot) {
-        return slot >= 0 && slot < stacks.size() ? stacks.get(slot) : ItemStack.EMPTY;
+        return slot >= 0 && slot < maxSize ? slots[slot] : ItemStack.EMPTY;
     }
 
     @Override
     public ItemStack removeItem(int slot, int amount) {
-        if (slot < 0 || slot >= stacks.size()) {
+        if (slot < 0 || slot >= maxSize || slots[slot].isEmpty()) {
             return ItemStack.EMPTY;
         }
-        ItemStack stack = stacks.get(slot);
-        if (stack.isEmpty()) {
-            return ItemStack.EMPTY;
-        }
+        ItemStack stack = slots[slot];
         int toRemove = Math.min(amount, stack.getCount());
         ItemStack removed = stack.copy();
         removed.setCount(toRemove);
         stack.shrink(toRemove);
         if (stack.isEmpty()) {
-            stacks.remove(slot);
+            slots[slot] = ItemStack.EMPTY; // clear without shifting later slots
         }
         return removed;
     }
 
     @Override
     public ItemStack removeItemNoUpdate(int slot) {
-        if (slot < 0 || slot >= stacks.size()) {
+        if (slot < 0 || slot >= maxSize) {
             return ItemStack.EMPTY;
         }
-        return stacks.remove(slot);
+        ItemStack stack = slots[slot];
+        slots[slot] = ItemStack.EMPTY;
+        return stack;
     }
 
     @Override
@@ -227,18 +261,9 @@ public class SteveInventory implements Container {
         if (slot < 0 || slot >= maxSize) {
             return;
         }
-        if (stack.isEmpty()) {
-            if (slot < stacks.size()) {
-                stacks.remove(slot);
-            }
-            return;
-        }
-        if (slot < stacks.size()) {
-            stacks.set(slot, stack);
-        } else if (slot == stacks.size() && stacks.size() < maxSize) {
-            stacks.add(stack);
-        }
-        // slot > size: ignore (client only sends valid slot operations)
+        // Any valid slot is written (including empty slots beyond the last
+        // non-empty one) - a placed item is never silently dropped.
+        slots[slot] = stack.isEmpty() ? ItemStack.EMPTY : stack.copy();
     }
 
     @Override
@@ -248,11 +273,17 @@ public class SteveInventory implements Container {
 
     @Override
     public boolean stillValid(Player player) {
-        return true;
+        if (owner == null) {
+            return true; // unit tests / detached inventory
+        }
+        return owner.isAlive()
+            && !owner.isRemoved()
+            && owner.level().dimension() == player.level().dimension()
+            && player.distanceToSqr(owner) <= 8.0 * 8.0;
     }
 
     @Override
     public void clearContent() {
-        stacks.clear();
+        Arrays.fill(slots, ItemStack.EMPTY);
     }
 }

--- a/src/main/java/com/steve/ai/entity/SteveInventory.java
+++ b/src/main/java/com/steve/ai/entity/SteveInventory.java
@@ -27,7 +27,12 @@ import java.util.List;
  */
 public class SteveInventory implements Container {
 
-    public static final int DEFAULT_SIZE = 36;
+    /**
+     * Default capacity: 27 slots (3 rows x 9), matching a vanilla single chest
+     * / the player's main grid. Deliberately small - capacity upgrades
+     * (backpacks etc.) can raise this later.
+     */
+    public static final int DEFAULT_SIZE = 27;
     private static final String NBT_KEY = "Inventory";
 
     private final ItemStack[] slots;

--- a/src/main/java/com/steve/ai/entity/SteveInventory.java
+++ b/src/main/java/com/steve/ai/entity/SteveInventory.java
@@ -7,6 +7,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -20,7 +21,6 @@ public class SteveInventory {
 
     public static final int DEFAULT_SIZE = 36;
     private static final String NBT_KEY = "Inventory";
-    private static final String NBT_SIZE = "Size";
 
     private final List<ItemStack> stacks;
     private final int maxSize;
@@ -123,8 +123,11 @@ public class SteveInventory {
         return maxSize;
     }
 
+    /**
+     * Read-only view of the stacks. Mutate only through the inventory methods.
+     */
     public List<ItemStack> getStacks() {
-        return stacks;
+        return Collections.unmodifiableList(stacks);
     }
 
     /**
@@ -142,13 +145,17 @@ public class SteveInventory {
             list.add(stack.save(new CompoundTag()));
         }
         tag.put(NBT_KEY, list);
-        tag.putInt(NBT_SIZE, maxSize);
     }
 
     public void loadFromNBT(CompoundTag tag) {
         stacks.clear();
         ListTag list = tag.getList(NBT_KEY, Tag.TAG_COMPOUND);
         for (int i = 0; i < list.size(); i++) {
+            // Preserve the invariant stacks.size() <= maxSize even if the NBT
+            // holds more entries than the configured capacity
+            if (stacks.size() >= maxSize) {
+                break;
+            }
             ItemStack stack = ItemStack.of(list.getCompound(i));
             if (!stack.isEmpty()) {
                 stacks.add(stack);

--- a/src/main/java/com/steve/ai/menu/SteveMenu.java
+++ b/src/main/java/com/steve/ai/menu/SteveMenu.java
@@ -10,17 +10,16 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
 /**
- * Container menu for Steve's inventory, laid out as a double chest
- * (6 rows x 9 = 54 slots) so the vanilla {@code generic_54} chest texture
- * renders it without custom geometry.
+ * Container menu for Steve's inventory, laid out as a vanilla single chest
+ * (3 rows x 9 = 27 slots) so the {@code generic_54} texture renders it with
+ * the exact vanilla single-chest blits - no custom geometry.
  *
  * <p>Steve's slots are read-only (players can only TAKE items, never place
- * them). The last two rows (slots 36-53) are empty and take-only too; they
- * exist only so the menu matches the double-chest layout.</p>
+ * them).</p>
  */
 public class SteveMenu extends AbstractContainerMenu {
 
-    private static final int STEVE_SLOTS = 54; // 6 rows x 9, double-chest layout
+    private static final int STEVE_SLOTS = 27; // 3 rows x 9, single-chest layout
     private static final int PLAYER_SLOTS_START = STEVE_SLOTS;
     private static final int SLOT_COUNT = STEVE_SLOTS + 36;
 
@@ -31,15 +30,15 @@ public class SteveMenu extends AbstractContainerMenu {
         this.container = container;
         container.startOpen(playerInventory.player);
 
-        // Steve's slots: 6 rows x 9, take-only (slots 36-53 read as EMPTY)
-        for (int row = 0; row < 6; row++) {
+        // Steve's slots: 3 rows x 9, take-only
+        for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
                 this.addSlot(new TakeOnlySlot(container, row * 9 + col, 8 + col * 18, 18 + row * 18));
             }
         }
 
-        // Player inventory: 3 rows x 9 + hotbar (double-chest offsets)
-        int playerOffset = (6 - 4) * 18; // 36
+        // Player inventory: 3 rows x 9 + hotbar (single-chest offsets)
+        int playerOffset = (3 - 4) * 18; // -18
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
                 this.addSlot(new Slot(playerInventory, col + row * 9 + 9,

--- a/src/main/java/com/steve/ai/menu/SteveMenu.java
+++ b/src/main/java/com/steve/ai/menu/SteveMenu.java
@@ -1,0 +1,117 @@
+package com.steve.ai.menu;
+
+import com.steve.ai.entity.SteveInventory;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Container menu for Steve's inventory. Steve's 36 slots are read-only
+ * (players can only TAKE items, never place them), the player's own
+ * inventory is shown below for direct transfers.
+ */
+public class SteveMenu extends AbstractContainerMenu {
+
+    private static final int STEVE_SLOTS = 36; // 4 rows x 9
+
+    private final SteveInventory container;
+
+    public SteveMenu(int containerId, Inventory playerInventory, SteveInventory container) {
+        super(com.steve.ai.menu.SteveMenus.STEVE_MENU.get(), containerId);
+        this.container = container;
+
+        checkContainerSize(container, STEVE_SLOTS);
+        container.startOpen(playerInventory.player);
+
+        // Steve's slots: 4 rows x 9, take-only
+        for (int row = 0; row < 4; row++) {
+            for (int col = 0; col < 9; col++) {
+                this.addSlot(new TakeOnlySlot(container, row * 9 + col, 8 + col * 18, 18 + row * 18));
+            }
+        }
+
+        // Player inventory: 3 rows x 9 + hotbar
+        for (int row = 0; row < 3; row++) {
+            for (int col = 0; col < 9; col++) {
+                this.addSlot(new Slot(playerInventory, col + row * 9 + 9, 8 + col * 18, 103 + row * 18));
+            }
+        }
+        for (int col = 0; col < 9; col++) {
+            this.addSlot(new Slot(playerInventory, col, 8 + col * 18, 161));
+        }
+    }
+
+    /**
+     * Client-side factory. The client container starts empty - the server
+     * synchronizes the real slot contents right after the menu opens
+     * (vanilla slot sync), so no Steve lookup is needed here.
+     */
+    public static SteveMenu fromNetwork(int containerId, Inventory playerInventory, FriendlyByteBuf extra) {
+        return new SteveMenu(containerId, playerInventory, new SteveInventory());
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int index) {
+        ItemStack result = ItemStack.EMPTY;
+        Slot slot = this.slots.get(index);
+        if (slot != null && slot.hasItem()) {
+            ItemStack stack = slot.getItem();
+            result = stack.copy();
+            if (index < STEVE_SLOTS) {
+                // Steve's slot -> player inventory
+                if (!this.moveItemStackTo(stack, STEVE_SLOTS, this.slots.size(), true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else {
+                // Player slot -> Steve's slots; blocked by mayPlace() = false
+                if (!this.moveItemStackTo(stack, 0, STEVE_SLOTS, false)) {
+                    return ItemStack.EMPTY;
+                }
+            }
+            if (stack.isEmpty()) {
+                slot.setByPlayer(ItemStack.EMPTY);
+            } else {
+                slot.setChanged();
+            }
+            if (stack.getCount() == result.getCount()) {
+                return ItemStack.EMPTY;
+            }
+            slot.onTake(player, stack);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return this.container.stillValid(player);
+    }
+
+    @Override
+    public void removed(Player player) {
+        super.removed(player);
+        this.container.stopOpen(player);
+    }
+
+    /**
+     * Slot that allows picking items up but never placing them.
+     */
+    private static class TakeOnlySlot extends Slot {
+        TakeOnlySlot(Container container, int slot, int x, int y) {
+            super(container, slot, x, y);
+        }
+
+        @Override
+        public boolean mayPlace(ItemStack stack) {
+            return false;
+        }
+
+        @Override
+        public boolean mayPickup(Player player) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/steve/ai/menu/SteveMenu.java
+++ b/src/main/java/com/steve/ai/menu/SteveMenu.java
@@ -10,38 +10,44 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
 /**
- * Container menu for Steve's inventory. Steve's 36 slots are read-only
- * (players can only TAKE items, never place them), the player's own
- * inventory is shown below for direct transfers.
+ * Container menu for Steve's inventory, laid out as a double chest
+ * (6 rows x 9 = 54 slots) so the vanilla {@code generic_54} chest texture
+ * renders it without custom geometry.
+ *
+ * <p>Steve's slots are read-only (players can only TAKE items, never place
+ * them). The last two rows (slots 36-53) are empty and take-only too; they
+ * exist only so the menu matches the double-chest layout.</p>
  */
 public class SteveMenu extends AbstractContainerMenu {
 
-    private static final int STEVE_SLOTS = 36; // 4 rows x 9
+    private static final int STEVE_SLOTS = 54; // 6 rows x 9, double-chest layout
+    private static final int PLAYER_SLOTS_START = STEVE_SLOTS;
+    private static final int SLOT_COUNT = STEVE_SLOTS + 36;
 
     private final SteveInventory container;
 
     public SteveMenu(int containerId, Inventory playerInventory, SteveInventory container) {
         super(com.steve.ai.menu.SteveMenus.STEVE_MENU.get(), containerId);
         this.container = container;
-
-        checkContainerSize(container, STEVE_SLOTS);
         container.startOpen(playerInventory.player);
 
-        // Steve's slots: 4 rows x 9, take-only
-        for (int row = 0; row < 4; row++) {
+        // Steve's slots: 6 rows x 9, take-only (slots 36-53 read as EMPTY)
+        for (int row = 0; row < 6; row++) {
             for (int col = 0; col < 9; col++) {
                 this.addSlot(new TakeOnlySlot(container, row * 9 + col, 8 + col * 18, 18 + row * 18));
             }
         }
 
-        // Player inventory: 3 rows x 9 + hotbar
+        // Player inventory: 3 rows x 9 + hotbar (double-chest offsets)
+        int playerOffset = (6 - 4) * 18; // 36
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
-                this.addSlot(new Slot(playerInventory, col + row * 9 + 9, 8 + col * 18, 103 + row * 18));
+                this.addSlot(new Slot(playerInventory, col + row * 9 + 9,
+                    8 + col * 18, 103 + playerOffset + row * 18));
             }
         }
         for (int col = 0; col < 9; col++) {
-            this.addSlot(new Slot(playerInventory, col, 8 + col * 18, 161));
+            this.addSlot(new Slot(playerInventory, col, 8 + col * 18, 161 + playerOffset));
         }
     }
 
@@ -63,7 +69,7 @@ public class SteveMenu extends AbstractContainerMenu {
             result = stack.copy();
             if (index < STEVE_SLOTS) {
                 // Steve's slot -> player inventory
-                if (!this.moveItemStackTo(stack, STEVE_SLOTS, this.slots.size(), true)) {
+                if (!this.moveItemStackTo(stack, PLAYER_SLOTS_START, SLOT_COUNT, true)) {
                     return ItemStack.EMPTY;
                 }
             } else {

--- a/src/main/java/com/steve/ai/menu/SteveMenus.java
+++ b/src/main/java/com/steve/ai/menu/SteveMenus.java
@@ -1,0 +1,22 @@
+package com.steve.ai.menu;
+
+import com.steve.ai.SteveMod;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraftforge.common.extensions.IForgeMenuType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/**
+ * Menu type registration for Steve's inventory menu.
+ */
+public final class SteveMenus {
+
+    public static final DeferredRegister<MenuType<?>> MENUS =
+        DeferredRegister.create(ForgeRegistries.MENU_TYPES, SteveMod.MODID);
+
+    public static final RegistryObject<MenuType<SteveMenu>> STEVE_MENU =
+        MENUS.register("steve_menu", () -> IForgeMenuType.create(SteveMenu::fromNetwork));
+
+    private SteveMenus() {}
+}

--- a/src/main/java/com/steve/ai/network/ClientboundInventoryPacket.java
+++ b/src/main/java/com/steve/ai/network/ClientboundInventoryPacket.java
@@ -42,6 +42,13 @@ public record ClientboundInventoryPacket(String steveName, List<ItemStack> stack
     }
 
     public static ClientboundInventoryPacket fromInventory(String steveName, SteveInventory inventory) {
-        return new ClientboundInventoryPacket(steveName, new ArrayList<>(inventory.getStacks()));
+        // Deep-copy every stack: the packet must own independent ItemStack
+        // objects, because the live inventory can be mutated (grow/shrink) in
+        // the server tick while encode() runs later on the network thread
+        List<ItemStack> copy = new ArrayList<>(inventory.getStacks().size());
+        for (ItemStack stack : inventory.getStacks()) {
+            copy.add(stack.copy());
+        }
+        return new ClientboundInventoryPacket(steveName, copy);
     }
 }

--- a/src/main/java/com/steve/ai/network/ClientboundInventoryPacket.java
+++ b/src/main/java/com/steve/ai/network/ClientboundInventoryPacket.java
@@ -1,0 +1,47 @@
+package com.steve.ai.network;
+
+import com.steve.ai.entity.SteveInventory;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Server -> Client: a Steve's inventory contents for the GUI panel.
+ */
+public record ClientboundInventoryPacket(String steveName, List<ItemStack> stacks) {
+
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeUtf(steveName, 64);
+        buf.writeVarInt(stacks.size());
+        for (ItemStack stack : stacks) {
+            buf.writeNbt(stack.save(new CompoundTag()));
+        }
+    }
+
+    public static ClientboundInventoryPacket decode(FriendlyByteBuf buf) {
+        String steveName = buf.readUtf(64);
+        int size = buf.readVarInt();
+        List<ItemStack> stacks = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            CompoundTag tag = buf.readNbt();
+            ItemStack stack = tag != null ? ItemStack.of(tag) : ItemStack.EMPTY;
+            if (!stack.isEmpty()) {
+                stacks.add(stack);
+            }
+        }
+        return new ClientboundInventoryPacket(steveName, stacks);
+    }
+
+    public static ClientboundInventoryPacket empty(String steveName) {
+        return new ClientboundInventoryPacket(steveName, List.of());
+    }
+
+    public static ClientboundInventoryPacket fromInventory(String steveName, SteveInventory inventory) {
+        return new ClientboundInventoryPacket(steveName, new ArrayList<>(inventory.getStacks()));
+    }
+}

--- a/src/main/java/com/steve/ai/network/ClientboundSteveListPacket.java
+++ b/src/main/java/com/steve/ai/network/ClientboundSteveListPacket.java
@@ -1,0 +1,28 @@
+package com.steve.ai.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Server -> Client: the list of active Steve names for the GUI panel.
+ */
+public record ClientboundSteveListPacket(List<String> steveNames) {
+
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeVarInt(steveNames.size());
+        for (String name : steveNames) {
+            buf.writeUtf(name, 64);
+        }
+    }
+
+    public static ClientboundSteveListPacket decode(FriendlyByteBuf buf) {
+        int size = buf.readVarInt();
+        List<String> names = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            names.add(buf.readUtf(64));
+        }
+        return new ClientboundSteveListPacket(names);
+    }
+}

--- a/src/main/java/com/steve/ai/network/ServerboundRequestInventoryPacket.java
+++ b/src/main/java/com/steve/ai/network/ServerboundRequestInventoryPacket.java
@@ -1,0 +1,17 @@
+package com.steve.ai.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+
+/**
+ * Client -> Server: request a Steve's inventory for the GUI panel.
+ */
+public record ServerboundRequestInventoryPacket(String steveName) {
+
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeUtf(steveName, 64);
+    }
+
+    public static ServerboundRequestInventoryPacket decode(FriendlyByteBuf buf) {
+        return new ServerboundRequestInventoryPacket(buf.readUtf(64));
+    }
+}

--- a/src/main/java/com/steve/ai/network/ServerboundRequestSteveListPacket.java
+++ b/src/main/java/com/steve/ai/network/ServerboundRequestSteveListPacket.java
@@ -1,0 +1,17 @@
+package com.steve.ai.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+
+/**
+ * Client -> Server: request the list of active Steve names for the GUI panel.
+ */
+public record ServerboundRequestSteveListPacket() {
+
+    public void encode(FriendlyByteBuf buf) {
+        // no payload
+    }
+
+    public static ServerboundRequestSteveListPacket decode(FriendlyByteBuf buf) {
+        return new ServerboundRequestSteveListPacket();
+    }
+}

--- a/src/main/java/com/steve/ai/network/SteveNetworking.java
+++ b/src/main/java/com/steve/ai/network/SteveNetworking.java
@@ -3,6 +3,8 @@ package com.steve.ai.network;
 import com.steve.ai.SteveMod;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.NetworkRegistry;
@@ -78,7 +80,8 @@ public final class SteveNetworking {
     private static void handleSteveList(ClientboundSteveListPacket packet,
                                         Supplier<NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> com.steve.ai.client.SteveGUI.setSteveList(packet.steveNames()));
+        ctx.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
+            () -> () -> com.steve.ai.client.SteveGUI.setSteveList(packet.steveNames())));
         ctx.setPacketHandled(true);
     }
 
@@ -104,8 +107,8 @@ public final class SteveNetworking {
     private static void handleInventory(ClientboundInventoryPacket packet,
                                         Supplier<NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> com.steve.ai.client.SteveGUI.setInventoryView(
-            packet.steveName(), packet.stacks()));
+        ctx.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
+            () -> () -> com.steve.ai.client.SteveGUI.setInventoryView(packet.steveName(), packet.stacks())));
         ctx.setPacketHandled(true);
     }
 }

--- a/src/main/java/com/steve/ai/network/SteveNetworking.java
+++ b/src/main/java/com/steve/ai/network/SteveNetworking.java
@@ -1,0 +1,111 @@
+package com.steve.ai.network;
+
+import com.steve.ai.SteveMod;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.PacketDistributor;
+import net.minecraftforge.network.simple.SimpleChannel;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Simple network channel for client <-> server communication
+ * (e.g. the GUI panel requesting a Steve's inventory).
+ */
+public final class SteveNetworking {
+
+    private static final String PROTOCOL_VERSION = "1";
+
+    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
+        new ResourceLocation(SteveMod.MODID, "main"),
+        () -> PROTOCOL_VERSION,
+        PROTOCOL_VERSION::equals,
+        PROTOCOL_VERSION::equals
+    );
+
+    private SteveNetworking() {}
+
+    public static void register() {
+        int id = 0;
+        CHANNEL.registerMessage(id++,
+            ServerboundRequestInventoryPacket.class,
+            ServerboundRequestInventoryPacket::encode,
+            ServerboundRequestInventoryPacket::decode,
+            SteveNetworking::handleRequestInventory,
+            Optional.of(NetworkDirection.PLAY_TO_SERVER));
+
+        CHANNEL.registerMessage(id++,
+            ClientboundInventoryPacket.class,
+            ClientboundInventoryPacket::encode,
+            ClientboundInventoryPacket::decode,
+            SteveNetworking::handleInventory,
+            Optional.of(NetworkDirection.PLAY_TO_CLIENT));
+
+        CHANNEL.registerMessage(id++,
+            ServerboundRequestSteveListPacket.class,
+            ServerboundRequestSteveListPacket::encode,
+            ServerboundRequestSteveListPacket::decode,
+            SteveNetworking::handleRequestSteveList,
+            Optional.of(NetworkDirection.PLAY_TO_SERVER));
+
+        CHANNEL.registerMessage(id++,
+            ClientboundSteveListPacket.class,
+            ClientboundSteveListPacket::encode,
+            ClientboundSteveListPacket::decode,
+            SteveNetworking::handleSteveList,
+            Optional.of(NetworkDirection.PLAY_TO_CLIENT));
+    }
+
+    private static void handleRequestSteveList(ServerboundRequestSteveListPacket packet,
+                                               Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context ctx = contextSupplier.get();
+        ctx.enqueueWork(() -> {
+            ServerPlayer sender = ctx.getSender();
+            if (sender == null) {
+                return;
+            }
+            ClientboundSteveListPacket response = new ClientboundSteveListPacket(
+                SteveMod.getSteveManager().getSteveNames());
+            CHANNEL.send(PacketDistributor.PLAYER.with(() -> sender), response);
+        });
+        ctx.setPacketHandled(true);
+    }
+
+    private static void handleSteveList(ClientboundSteveListPacket packet,
+                                        Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context ctx = contextSupplier.get();
+        ctx.enqueueWork(() -> com.steve.ai.client.SteveGUI.setSteveList(packet.steveNames()));
+        ctx.setPacketHandled(true);
+    }
+
+    private static void handleRequestInventory(ServerboundRequestInventoryPacket packet,
+                                               Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context ctx = contextSupplier.get();
+        ctx.enqueueWork(() -> {
+            ServerPlayer sender = ctx.getSender();
+            if (sender == null) {
+                return;
+            }
+            var steve = SteveMod.getSteveManager().getSteve(packet.steveName());
+            if (steve == null) {
+                return;
+            }
+            ClientboundInventoryPacket response =
+                ClientboundInventoryPacket.fromInventory(steve.getSteveName(), steve.getInventory());
+            CHANNEL.send(PacketDistributor.PLAYER.with(() -> sender), response);
+        });
+        ctx.setPacketHandled(true);
+    }
+
+    private static void handleInventory(ClientboundInventoryPacket packet,
+                                        Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context ctx = contextSupplier.get();
+        ctx.enqueueWork(() -> com.steve.ai.client.SteveGUI.setInventoryView(
+            packet.steveName(), packet.stacks()));
+        ctx.setPacketHandled(true);
+    }
+}

--- a/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
@@ -1,0 +1,172 @@
+package com.steve.ai.entity;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.WorldVersion;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.storage.DataVersion;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for SteveInventory (add/merge/capacity/NBT logic).
+ *
+ * Vanilla Items require Minecraft's registries, which are initialized via
+ * SharedConstants.setVersion + Bootstrap.bootStrap() before the tests.
+ */
+class SteveInventoryTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.setVersion(new WorldVersion() {
+            @Override
+            public String getName() { return "1.20.1"; }
+            @Override
+            public String getId() { return "1.20.1"; }
+            @Override
+            public DataVersion getDataVersion() { return new DataVersion(3465); }
+            @Override
+            public int getProtocolVersion() { return 765; }
+            @Override
+            public int getPackVersion(PackType type) { return 15; }
+            @Override
+            public Date getBuildTime() { return new Date(0); }
+            @Override
+            public boolean isStable() { return true; }
+        });
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void addItemMergesIntoExistingStack() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 20));
+
+        assertEquals(1, inventory.getStacksCount(), "Same item must merge into one stack");
+        assertEquals(30, inventory.countItem(Items.OAK_LOG));
+        assertEquals(30, inventory.getTotalCount());
+    }
+
+    @Test
+    void addItemCreatesNewStacksForDifferentItems() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+        inventory.addItem(new ItemStack(Items.IRON_INGOT, 5));
+
+        assertEquals(2, inventory.getStacksCount());
+        assertEquals(10, inventory.countItem(Items.OAK_LOG));
+        assertEquals(5, inventory.countItem(Items.IRON_INGOT));
+    }
+
+    @Test
+    void addItemReturnsRemainderWhenInventoryIsFull() {
+        SteveInventory inventory = new SteveInventory(2);
+        assertTrue(inventory.addItem(new ItemStack(Items.OAK_LOG, 64)).isEmpty());
+        assertTrue(inventory.addItem(new ItemStack(Items.OAK_LOG, 64)).isEmpty());
+
+        ItemStack remainder = inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+        assertEquals(10, remainder.getCount(), "Nothing fits - full stack must be returned");
+        assertEquals(128, inventory.getTotalCount());
+    }
+
+    @Test
+    void addItemSplitsOversizedStackAcrossSlots() {
+        SteveInventory inventory = new SteveInventory(9);
+        // 150 oak logs in a 64-max stack: 64 + 64 + 22
+        ItemStack remainder = inventory.addItem(new ItemStack(Items.OAK_LOG, 150));
+
+        assertTrue(remainder.isEmpty());
+        assertEquals(3, inventory.getStacksCount());
+        assertEquals(150, inventory.countItem(Items.OAK_LOG));
+    }
+
+    @Test
+    void addItemReturnsPartialRemainderWhenCapacityRunsOut() {
+        SteveInventory inventory = new SteveInventory(1);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 60));
+
+        // Only 4 fit into the existing stack's remaining space, 56 must come back
+        ItemStack remainder = inventory.addItem(new ItemStack(Items.OAK_LOG, 60));
+        assertEquals(56, remainder.getCount());
+        assertEquals(64, inventory.getTotalCount());
+    }
+
+    @Test
+    void hasFreeSpaceReflectsCapacity() {
+        SteveInventory inventory = new SteveInventory(1);
+        assertTrue(inventory.hasFreeSpace());
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 64));
+        assertFalse(inventory.hasFreeSpace(), "Single full stack - no free space");
+    }
+
+    @Test
+    void countItemIsZeroForUnknownItem() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 3));
+        assertEquals(0, inventory.countItem(Items.DIAMOND));
+    }
+
+    @Test
+    void takeAllClearsInventory() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+        inventory.addItem(new ItemStack(Items.IRON_INGOT, 5));
+
+        var taken = inventory.takeAll();
+        assertEquals(2, taken.size());
+        assertTrue(inventory.isEmpty());
+        assertEquals(0, inventory.getTotalCount());
+    }
+
+    @Test
+    void getStacksIsUnmodifiable() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 1));
+
+        assertThrows(UnsupportedOperationException.class,
+            () -> inventory.getStacks().clear());
+    }
+
+    @Test
+    void nbtRoundTripPreservesContents() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+        inventory.addItem(new ItemStack(Items.IRON_INGOT, 5));
+
+        CompoundTag tag = new CompoundTag();
+        inventory.saveToNBT(tag);
+
+        SteveInventory loaded = new SteveInventory(9);
+        loaded.loadFromNBT(tag);
+
+        assertEquals(2, loaded.getStacksCount());
+        assertEquals(10, loaded.countItem(Items.OAK_LOG));
+        assertEquals(5, loaded.countItem(Items.IRON_INGOT));
+    }
+
+    @Test
+    void loadFromNBTClampsToMaxSize() {
+        // Craft a tag with more entries than maxSize
+        CompoundTag tag = new CompoundTag();
+        ListTag list = new ListTag();
+        for (int i = 0; i < 40; i++) {
+            list.add(new ItemStack(Items.OAK_LOG, 1).save(new CompoundTag()));
+        }
+        tag.put("Inventory", list);
+
+        SteveInventory loaded = new SteveInventory(9);
+        loaded.loadFromNBT(tag);
+        assertEquals(9, loaded.getStacksCount(),
+            "Load must clamp to maxSize even with oversized NBT");
+    }
+}

--- a/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
@@ -169,4 +169,59 @@ class SteveInventoryTest {
         assertEquals(9, loaded.getStacksCount(),
             "Load must clamp to maxSize even with oversized NBT");
     }
+
+    // ==================== Container (chest menu) access ====================
+
+    @Test
+    void containerGetItemReturnsEmptyForOutOfRangeSlot() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+
+        assertTrue(inventory.getItem(0).isEmpty() == false);
+        assertTrue(inventory.getItem(5).isEmpty(), "Slot beyond stack list is empty");
+        assertTrue(inventory.getItem(-1).isEmpty());
+        assertEquals(9, inventory.getContainerSize());
+    }
+
+    @Test
+    void containerRemoveItemTakesPartialStack() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+
+        ItemStack taken = inventory.removeItem(0, 3);
+        assertEquals(3, taken.getCount());
+        assertEquals(7, inventory.countItem(Items.OAK_LOG));
+        assertEquals(1, inventory.getStacksCount());
+    }
+
+    @Test
+    void containerRemoveItemRemovesSlotWhenEmpty() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+
+        ItemStack taken = inventory.removeItem(0, 64);
+        assertEquals(10, taken.getCount());
+        assertTrue(inventory.isEmpty(), "Slot must be removed when fully emptied");
+    }
+
+    @Test
+    void containerSetItemPlacesAndReplaces() {
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+
+        // Replace slot 0
+        inventory.setItem(0, new ItemStack(Items.IRON_INGOT, 5));
+        assertEquals(5, inventory.countItem(Items.IRON_INGOT));
+        assertEquals(0, inventory.countItem(Items.OAK_LOG));
+
+        // Append a new slot at the end
+        inventory.setItem(1, new ItemStack(Items.DIAMOND, 2));
+        assertEquals(2, inventory.countItem(Items.DIAMOND));
+        assertEquals(2, inventory.getStacksCount());
+
+        // Empty stack removes the slot
+        inventory.setItem(0, ItemStack.EMPTY);
+        assertEquals(1, inventory.getStacksCount());
+        assertEquals(0, inventory.countItem(Items.IRON_INGOT));
+    }
 }

--- a/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
@@ -173,12 +173,12 @@ class SteveInventoryTest {
     // ==================== Container (chest menu) access ====================
 
     @Test
-    void containerGetItemReturnsEmptyForOutOfRangeSlot() {
+    void containerGetItemReturnsEmptyForEmptySlot() {
         SteveInventory inventory = new SteveInventory(9);
         inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
 
-        assertTrue(inventory.getItem(0).isEmpty() == false);
-        assertTrue(inventory.getItem(5).isEmpty(), "Slot beyond stack list is empty");
+        assertFalse(inventory.getItem(0).isEmpty());
+        assertTrue(inventory.getItem(5).isEmpty(), "Empty slot reads as EMPTY");
         assertTrue(inventory.getItem(-1).isEmpty());
         assertEquals(9, inventory.getContainerSize());
     }
@@ -195,13 +195,17 @@ class SteveInventoryTest {
     }
 
     @Test
-    void containerRemoveItemRemovesSlotWhenEmpty() {
+    void containerRemoveItemClearsSlotWithoutShifting() {
         SteveInventory inventory = new SteveInventory(9);
         inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+        inventory.addItem(new ItemStack(Items.DIAMOND, 2)); // slot 1
 
         ItemStack taken = inventory.removeItem(0, 64);
         assertEquals(10, taken.getCount());
-        assertTrue(inventory.isEmpty(), "Slot must be removed when fully emptied");
+        assertTrue(inventory.getItem(0).isEmpty(), "Slot 0 must be empty after removal");
+        assertTrue(inventory.getItem(1).is(Items.DIAMOND),
+            "Slot 1 must keep DIAMOND - indices must stay stable");
+        assertEquals(2, inventory.countItem(Items.DIAMOND));
     }
 
     @Test
@@ -214,14 +218,38 @@ class SteveInventoryTest {
         assertEquals(5, inventory.countItem(Items.IRON_INGOT));
         assertEquals(0, inventory.countItem(Items.OAK_LOG));
 
-        // Append a new slot at the end
+        // Write into an empty slot beyond the last non-empty one
         inventory.setItem(1, new ItemStack(Items.DIAMOND, 2));
         assertEquals(2, inventory.countItem(Items.DIAMOND));
         assertEquals(2, inventory.getStacksCount());
 
-        // Empty stack removes the slot
+        // Clearing slot 0 must NOT shift DIAMOND out of slot 1
         inventory.setItem(0, ItemStack.EMPTY);
+        assertTrue(inventory.getItem(0).isEmpty());
+        assertTrue(inventory.getItem(1).is(Items.DIAMOND));
         assertEquals(1, inventory.getStacksCount());
         assertEquals(0, inventory.countItem(Items.IRON_INGOT));
+    }
+
+    @Test
+    void setItemIntoEmptySlotBeyondStacksIsNotLost() {
+        // Regression: with a compact list, placing into slot 5 while only
+        // slot 0 is occupied silently dropped the item (cursor was consumed).
+        SteveInventory inventory = new SteveInventory(9);
+        inventory.addItem(new ItemStack(Items.OAK_LOG, 10));
+
+        inventory.setItem(5, new ItemStack(Items.DIAMOND, 3));
+
+        assertTrue(inventory.getItem(5).is(Items.DIAMOND),
+            "Item placed into an empty slot must be stored, not dropped");
+        assertEquals(3, inventory.countItem(Items.DIAMOND));
+        assertEquals(2, inventory.getStacksCount());
+    }
+
+    @Test
+    void stillValidWithoutOwnerReturnsTrue() {
+        SteveInventory inventory = new SteveInventory(9);
+        assertTrue(inventory.stillValid(null),
+            "Detached inventory (unit tests) must be considered valid");
     }
 }


### PR DESCRIPTION
## Что делает
Стив получает инвентарь (27 слотов, NBT) и подбирает предметы с земли. Инвентарь можно смотреть в панели K (вкладка Inv) и командой `/steve inventory <name>`.

## Изменения
- **SteveInventory**: 27 слотов, стаки, NBT, hasFreeSpace/countItem/takeAll
- **Подбор**: вакуум ItemEntity каждые 10 тиков, радиус 3 блока, остаток возвращается на землю
- **Сеть**: SimpleChannel (4 пакета: список Стивов + инвентарь)
- **Панель K**: вкладки Chat/Inv (Tab или клик), список Стивов с выбором, сетка слотов
- **/steve inventory <name>**: текстовый вывод
- **Фикс**: панель получает список Стивов с сервера (раньше клиентский SteveManager был всегда пуст → команды из панели не работали)

## Проверка
- [x] Локальная компиляция + тесты (1 ядро/2ГБ)
- [ ] CI на PR
- [ ] Живой тест после мержа

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Добавлен инвентарь Steve с ограниченной вместимостью, объединением предметов и сохранением содержимого.
  - Steve автоматически подбирает ближайшие предметы, пока есть свободное место.
  - При удалении Steve его содержимое выпадает в игровой мир.
  - Добавлен интерфейс просмотра списка Steve и содержимого их инвентарей.
  - Инвентарь Steve можно открыть при взаимодействии с ним и забирать предметы.
  - Добавлена команда `/steve inventory <имя>` для просмотра инвентаря.
  - Список Steve и инвентари синхронизируются между сервером и клиентом.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->