### PR TITLE
#9 Баг: боты дублируются после перезахода в игру; remove находит только один экземпляр

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     // JUnit 5 for testing
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+    testImplementation 'org.mockito:mockito-core:5.23.0'
 }
 
 test {

--- a/src/main/java/com/steve/ai/command/SteveCommands.java
+++ b/src/main/java/com/steve/ai/command/SteveCommands.java
@@ -282,7 +282,7 @@ public class SteveCommands {
         CommandSourceStack source = context.getSource();
         
         SteveManager manager = SteveMod.getSteveManager();
-        if (manager.removeSteve(name)) {
+        if (manager.removeSteve(name, source.getServer())) {
             source.sendSuccess(() -> Component.literal("Removed Steve: " + name), true);
             return 1;
         } else {

--- a/src/main/java/com/steve/ai/entity/SteveEntity.java
+++ b/src/main/java/com/steve/ai/entity/SteveEntity.java
@@ -43,6 +43,9 @@ public class SteveEntity extends PathfinderMob {
     private int pickupCooldown = 0;
     private boolean isFlying = false;
     private boolean isInvulnerable = false;
+    /** When true, remove() must not drop the inventory into the world. Used when
+     *  discarding a duplicate bot so its NBT-inventory is not duped as items. */
+    private boolean suppressInventoryDrop = false;
 
     /** Pickup radius for items lying on the ground, in blocks. */
     private static final double PICKUP_RADIUS = 3.0;
@@ -87,13 +90,19 @@ public class SteveEntity extends PathfinderMob {
         // Drop the inventory into the world when Steve is killed or discarded
         // (/kill, /steve remove) instead of silently losing the contents.
         // Unloading/changing dimension must keep the inventory (it is in NBT).
-        if (!this.level().isClientSide && !inventory.isEmpty()
+        // Dedup discards of duplicate bots must NOT drop: the duplicate carries
+        // the same NBT inventory, so dropping it would be an item-dupe exploit.
+        if (!this.level().isClientSide && !suppressInventoryDrop && !inventory.isEmpty()
                 && (reason == RemovalReason.KILLED || reason == RemovalReason.DISCARDED)) {
             for (ItemStack stack : inventory.takeAll()) {
                 this.spawnAtLocation(stack);
             }
         }
         super.remove(reason);
+    }
+
+    public void setSuppressInventoryDrop(boolean suppress) {
+        this.suppressInventoryDrop = suppress;
     }
 
     @Override

--- a/src/main/java/com/steve/ai/entity/SteveEntity.java
+++ b/src/main/java/com/steve/ai/entity/SteveEntity.java
@@ -43,9 +43,21 @@ public class SteveEntity extends PathfinderMob {
     private int pickupCooldown = 0;
     private boolean isFlying = false;
     private boolean isInvulnerable = false;
-    /** When true, remove() must not drop the inventory into the world. Used when
-     *  discarding a duplicate bot so its NBT-inventory is not duped as items. */
+    /**
+     * When true, remove() must not drop the inventory into the world. Used when
+     * discarding a duplicate bot so its NBT-inventory is not duped as items.
+     * Intentionally NOT reset after remove(): the entity is being discarded and
+     * will never tick or be reused again, so there is no stale state to clear.
+     */
     private boolean suppressInventoryDrop = false;
+
+    /**
+     * True when this instance was deserialized from NBT (chunk load / dimension
+     * load) and therefore carries persisted state (inventory, memory). Freshly
+     * spawned instances keep this false. Used by the manager dedup to prefer a
+     * chunk-loaded bot over an empty fresh spawn with the same name.
+     */
+    private boolean loadedFromNbt = false;
 
     /** Pickup radius for items lying on the ground, in blocks. */
     private static final double PICKUP_RADIUS = 3.0;
@@ -103,6 +115,11 @@ public class SteveEntity extends PathfinderMob {
 
     public void setSuppressInventoryDrop(boolean suppress) {
         this.suppressInventoryDrop = suppress;
+    }
+
+    /** True when this instance was loaded from NBT (persisted state). */
+    public boolean isLoadedFromNbt() {
+        return this.loadedFromNbt;
     }
 
     @Override
@@ -241,6 +258,7 @@ public class SteveEntity extends PathfinderMob {
     @Override
     public void readAdditionalSaveData(CompoundTag tag) {
         super.readAdditionalSaveData(tag);
+        this.loadedFromNbt = true;
         if (tag.contains("SteveName")) {
             this.setSteveName(tag.getString("SteveName"));
         }

--- a/src/main/java/com/steve/ai/entity/SteveManager.java
+++ b/src/main/java/com/steve/ai/entity/SteveManager.java
@@ -2,7 +2,9 @@ package com.steve.ai.entity;
 
 import com.steve.ai.SteveMod;
 import com.steve.ai.config.SteveConfig;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.phys.Vec3;
 
@@ -18,10 +20,58 @@ public class SteveManager {
         this.stevesByUUID = new ConcurrentHashMap<>();
     }
 
+    /**
+     * Registers a SteveEntity that entered the world (fresh spawn or loaded
+     * from a chunk / NBT). If the name is already taken by another live
+     * instance, the newcomer is a duplicate and gets discarded (dedup):
+     * the first registered instance wins. Re-adopting the same instance is
+     * a no-op (idempotent).
+     *
+     * @return the adopted instance, or null if it was discarded as a duplicate
+     */
+    public SteveEntity adopt(SteveEntity steve) {
+        if (steve == null) {
+            return null;
+        }
+        String name = steve.getSteveName();
+        SteveEntity existing = activeSteves.get(name);
+        if (existing != null) {
+            if (existing == steve) {
+                return steve;
+            }
+            if (!existing.isAlive() || existing.isRemoved()) {
+                // Stale registry entry (e.g. survivor of a crash) - replace it
+                activeSteves.remove(name);
+                stevesByUUID.remove(existing.getUUID());
+            } else {
+                // Duplicate bot with the same name: discard the newcomer. Its
+                // NBT-inventory equals the survivor's, so suppress the drop to
+                // avoid an item-dupe exploit.
+                steve.setSuppressInventoryDrop(true);
+                steve.discard();
+                SteveMod.LOGGER.info("Dedup: discarded duplicate Steve '{}' ({}) - another live instance exists",
+                        name, steve.getUUID());
+                return null;
+            }
+        }
+        activeSteves.put(name, steve);
+        stevesByUUID.put(steve.getUUID(), steve);
+        return steve;
+    }
+
     public SteveEntity spawnSteve(ServerLevel level, Vec3 position, String name) {        SteveMod.LOGGER.info("Current active Steves: {}", activeSteves.size());
         
         if (activeSteves.containsKey(name)) {
             SteveMod.LOGGER.warn("Steve name '{}' already exists", name);
+            return null;
+        }
+        // Uniqueness check against the world itself: a bot with this name may
+        // be loaded from a chunk but not tracked yet - adopt it instead of
+        // spawning a duplicate.
+        SteveEntity existing = findSteveInLevel(level, name);
+        if (existing != null) {
+            adopt(existing);
+            SteveMod.LOGGER.warn("Steve name '{}' already exists in world, adopting existing instance", name);
             return null;
         }        int maxSteves = SteveConfig.MAX_ACTIVE_STEVES.get();        if (activeSteves.size() >= maxSteves) {
             SteveMod.LOGGER.warn("Max Steve limit reached: {}", maxSteves);
@@ -53,6 +103,25 @@ public class SteveManager {
         return null;
     }
 
+    /**
+     * Scans the given level for a live SteveEntity that carries this name but
+     * is not necessarily tracked yet (e.g. loaded from a chunk). Used to stop
+     * /steve spawn from creating a duplicate over an existing world instance.
+     */
+    private SteveEntity findSteveInLevel(ServerLevel level, String name) {
+        if (level == null) {
+            return null;
+        }
+        for (Entity entity : level.getAllEntities()) {
+            if (entity instanceof SteveEntity steve
+                    && name.equals(steve.getSteveName())
+                    && steve.isAlive() && !steve.isRemoved()) {
+                return steve;
+            }
+        }
+        return null;
+    }
+
     public SteveEntity getSteve(String name) {
         return activeSteves.get(name);
     }
@@ -62,12 +131,64 @@ public class SteveManager {
     }
 
     public boolean removeSteve(String name) {
-        SteveEntity steve = activeSteves.remove(name);
-        if (steve != null) {
-            stevesByUUID.remove(steve.getUUID());
-            steve.discard();            return true;
+        // Preserve the single-argument contract: also discard the tracked bot.
+        SteveEntity tracked = activeSteves.remove(name);
+        if (tracked != null) {
+            stevesByUUID.remove(tracked.getUUID());
+            tracked.discard();
+            return true;
         }
         return false;
+    }
+
+    /**
+     * Removes every live SteveEntity with the given name from all server
+     * levels and cleans up the registries. The world sweep is required
+     * because a bot loaded from NBT may exist in a chunk without being
+     * tracked in the maps (e.g. after the dedup auto-spawn regression).
+     */
+    public boolean removeSteve(String name, MinecraftServer server) {
+        boolean removed = false;
+        if (server != null) {
+            // Collect first, discard after: iterating getAllEntities() while
+            // removing entities from it would throw a concurrent-modification.
+            List<SteveEntity> matches = new ArrayList<>();
+            for (ServerLevel level : server.getAllLevels()) {
+                for (Entity entity : level.getAllEntities()) {
+                    if (entity instanceof SteveEntity steve && name.equals(steve.getSteveName())) {
+                        matches.add(steve);
+                    }
+                }
+            }
+            for (SteveEntity steve : matches) {
+                steve.discard();
+                removed = true;
+            }
+        }
+        SteveEntity tracked = activeSteves.remove(name);
+        if (tracked != null) {
+            stevesByUUID.remove(tracked.getUUID());
+            removed = true;
+        }
+        return removed;
+    }
+
+    /**
+     * Cleans up the registries when a tracked Steve is unloaded from the
+     * world (chunk unload / dimension change). The bot will be re-adopted
+     * via {@link #adopt(SteveEntity)} when its chunk loads again.
+     */
+    public void onSteveUnload(SteveEntity steve) {
+        if (steve == null) {
+            return;
+        }
+        String name = steve.getSteveName();
+        SteveEntity tracked = activeSteves.get(name);
+        if (tracked == steve) {
+            activeSteves.remove(name);
+            SteveMod.LOGGER.info("Steve '{}' unloaded from world, removed from registry", name);
+        }
+        stevesByUUID.remove(steve.getUUID());
     }
 
     public void clearAllSteves() {

--- a/src/main/java/com/steve/ai/entity/SteveManager.java
+++ b/src/main/java/com/steve/ai/entity/SteveManager.java
@@ -11,6 +11,8 @@ import net.minecraft.world.phys.Vec3;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.util.Objects.requireNonNull;
+
 public class SteveManager {
     private final Map<String, SteveEntity> activeSteves;
     private final Map<UUID, SteveEntity> stevesByUUID;
@@ -23,9 +25,16 @@ public class SteveManager {
     /**
      * Registers a SteveEntity that entered the world (fresh spawn or loaded
      * from a chunk / NBT). If the name is already taken by another live
-     * instance, the newcomer is a duplicate and gets discarded (dedup):
-     * the first registered instance wins. Re-adopting the same instance is
-     * a no-op (idempotent).
+     * instance, the newcomer is a duplicate and gets discarded (dedup).
+     *
+     * <p>When the survivor and the newcomer disagree on origin, the instance
+     * loaded from NBT wins: it carries the real persisted state (inventory,
+     * memory), while a freshly spawned one is an empty replacement. This
+     * protects the original bot from being destroyed in favour of an empty
+     * copy when its chunk loads after a fresh spawn with the same name. When
+     * both come from the same origin the first registered instance wins.
+     *
+     * <p>Re-adopting the same instance is a no-op (idempotent).
      *
      * @return the adopted instance, or null if it was discarded as a duplicate
      */
@@ -33,7 +42,7 @@ public class SteveManager {
         if (steve == null) {
             return null;
         }
-        String name = steve.getSteveName();
+        String name = requireNonNull(steve.getSteveName(), "Steve name must not be null");
         SteveEntity existing = activeSteves.get(name);
         if (existing != null) {
             if (existing == steve) {
@@ -41,6 +50,16 @@ public class SteveManager {
             }
             if (!existing.isAlive() || existing.isRemoved()) {
                 // Stale registry entry (e.g. survivor of a crash) - replace it
+                activeSteves.remove(name);
+                stevesByUUID.remove(existing.getUUID());
+            } else if (steve.isLoadedFromNbt() && !existing.isLoadedFromNbt()) {
+                // The newcomer is the real bot loaded from NBT; the survivor is
+                // a freshly spawned empty copy. Keep the NBT state, discard the
+                // empty copy without dropping its (empty) inventory.
+                existing.setSuppressInventoryDrop(true);
+                existing.discard();
+                SteveMod.LOGGER.info("Dedup: replaced fresh duplicate '{}' ({}) with NBT-loaded original ({})",
+                        name, existing.getUUID(), steve.getUUID());
                 activeSteves.remove(name);
                 stevesByUUID.remove(existing.getUUID());
             } else {
@@ -59,8 +78,10 @@ public class SteveManager {
         return steve;
     }
 
-    public SteveEntity spawnSteve(ServerLevel level, Vec3 position, String name) {        SteveMod.LOGGER.info("Current active Steves: {}", activeSteves.size());
-        
+    public SteveEntity spawnSteve(ServerLevel level, Vec3 position, String name) {
+        name = requireNonNull(name, "Steve name must not be null");
+        SteveMod.LOGGER.info("Current active Steves: {}", activeSteves.size());
+
         if (activeSteves.containsKey(name)) {
             SteveMod.LOGGER.warn("Steve name '{}' already exists", name);
             return null;
@@ -73,12 +94,19 @@ public class SteveManager {
             adopt(existing);
             SteveMod.LOGGER.warn("Steve name '{}' already exists in world, adopting existing instance", name);
             return null;
-        }        int maxSteves = SteveConfig.MAX_ACTIVE_STEVES.get();        if (activeSteves.size() >= maxSteves) {
+        }
+
+        int maxSteves = SteveConfig.MAX_ACTIVE_STEVES.get();
+        if (activeSteves.size() >= maxSteves) {
             SteveMod.LOGGER.warn("Max Steve limit reached: {}", maxSteves);
             return null;
-        }        SteveEntity steve;
-        try {            SteveMod.LOGGER.info("EntityType: {}", SteveMod.STEVE_ENTITY.get());
-            steve = new SteveEntity(SteveMod.STEVE_ENTITY.get(), level);        } catch (Throwable e) {
+        }
+
+        SteveEntity steve;
+        try {
+            SteveMod.LOGGER.info("EntityType: {}", SteveMod.STEVE_ENTITY.get());
+            steve = new SteveEntity(SteveMod.STEVE_ENTITY.get(), level);
+        } catch (Throwable e) {
             SteveMod.LOGGER.error("Failed to create Steve entity", e);
             SteveMod.LOGGER.error("Exception class: {}", e.getClass().getName());
             SteveMod.LOGGER.error("Exception message: {}", e.getMessage());
@@ -86,10 +114,26 @@ public class SteveManager {
             return null;
         }
 
-        try {            steve.setSteveName(name);            steve.setPos(position.x, position.y, position.z);            boolean added = level.addFreshEntity(steve);            if (added) {
-                activeSteves.put(name, steve);
-                stevesByUUID.put(steve.getUUID(), steve);
-                SteveMod.LOGGER.info("Successfully spawned Steve: {} with UUID {} at {}", name, steve.getUUID(), position);                return steve;
+        try {
+            steve.setSteveName(name);
+            steve.setPos(position.x, position.y, position.z);
+            boolean added = level.addFreshEntity(steve);
+            if (added) {
+                // Registration is done by adopt() via onEntityJoinLevel - do not
+                // touch the registries here. Verify that adopt accepted this
+                // exact instance; a same-named Steve may have been loaded
+                // concurrently and won the dedup, in which case steve was
+                // already discarded.
+                if (activeSteves.get(name) == steve && steve.isAlive()) {
+                    SteveMod.LOGGER.info("Successfully spawned Steve: {} with UUID {} at {}", name, steve.getUUID(), position);
+                    return steve;
+                } else {
+                    SteveMod.LOGGER.warn("Steve '{}' was added to the world but adopt() did not register it - discarding", name);
+                    if (!steve.isRemoved()) {
+                        steve.setSuppressInventoryDrop(true);
+                        steve.discard();
+                    }
+                }
             } else {
                 SteveMod.LOGGER.error("Failed to add Steve entity to world (addFreshEntity returned false)");
                 SteveMod.LOGGER.error("=== SPAWN ATTEMPT FAILED ===");
@@ -109,7 +153,7 @@ public class SteveManager {
      * /steve spawn from creating a duplicate over an existing world instance.
      */
     private SteveEntity findSteveInLevel(ServerLevel level, String name) {
-        if (level == null) {
+        if (level == null || name == null) {
             return null;
         }
         for (Entity entity : level.getAllEntities()) {
@@ -123,22 +167,11 @@ public class SteveManager {
     }
 
     public SteveEntity getSteve(String name) {
-        return activeSteves.get(name);
+        return name == null ? null : activeSteves.get(name);
     }
 
     public SteveEntity getSteve(UUID uuid) {
-        return stevesByUUID.get(uuid);
-    }
-
-    public boolean removeSteve(String name) {
-        // Preserve the single-argument contract: also discard the tracked bot.
-        SteveEntity tracked = activeSteves.remove(name);
-        if (tracked != null) {
-            stevesByUUID.remove(tracked.getUUID());
-            tracked.discard();
-            return true;
-        }
-        return false;
+        return uuid == null ? null : stevesByUUID.get(uuid);
     }
 
     /**
@@ -146,8 +179,16 @@ public class SteveManager {
      * levels and cleans up the registries. The world sweep is required
      * because a bot loaded from NBT may exist in a chunk without being
      * tracked in the maps (e.g. after the dedup auto-spawn regression).
+     *
+     * <p>When several same-named instances exist in the world (a bug), only
+     * the tracked instance may drop its inventory; every other duplicate has
+     * its inventory drop suppressed so the (identical, duplicated) contents
+     * are not dropped multiple times - an item-dupe exploit.
      */
     public boolean removeSteve(String name, MinecraftServer server) {
+        if (name == null) {
+            return false;
+        }
         boolean removed = false;
         if (server != null) {
             // Collect first, discard after: iterating getAllEntities() while
@@ -160,7 +201,17 @@ public class SteveManager {
                     }
                 }
             }
+            SteveEntity tracked = activeSteves.get(name);
             for (SteveEntity steve : matches) {
+                if (!steve.isAlive() || steve.isRemoved()) {
+                    continue;
+                }
+                if (steve != tracked) {
+                    // Same-named duplicate: dropping its (identical) contents
+                    // would dupe items, so suppress the drop for non-tracked
+                    // copies. The tracked instance keeps the normal drop.
+                    steve.setSuppressInventoryDrop(true);
+                }
                 steve.discard();
                 removed = true;
             }
@@ -174,21 +225,41 @@ public class SteveManager {
     }
 
     /**
-     * Cleans up the registries when a tracked Steve is unloaded from the
-     * world (chunk unload / dimension change). The bot will be re-adopted
-     * via {@link #adopt(SteveEntity)} when its chunk loads again.
+     * Cleans up the registries when a tracked Steve leaves the world for a
+     * reason other than a dimension change: chunk unload, kill or discard.
+     * The bot is re-adopted via {@link #adopt(SteveEntity)} when its chunk
+     * loads again. A dimension change keeps the registration: the same live
+     * instance continues to exist and is re-adopted (idempotently) on join.
      */
     public void onSteveUnload(SteveEntity steve) {
         if (steve == null) {
             return;
         }
-        String name = steve.getSteveName();
+        String name = requireNonNull(steve.getSteveName(), "Steve name must not be null");
         SteveEntity tracked = activeSteves.get(name);
         if (tracked == steve) {
             activeSteves.remove(name);
-            SteveMod.LOGGER.info("Steve '{}' unloaded from world, removed from registry", name);
+            SteveMod.LOGGER.info("Steve '{}' left the world, removed from registry", name);
         }
         stevesByUUID.remove(steve.getUUID());
+    }
+
+    /**
+     * Periodic registry cleanup: drops entries whose entity is dead or
+     * removed. Safety net for removal reasons that do not go through
+     * {@link #onSteveUnload(SteveEntity)}.
+     */
+    public void tick() {
+        Iterator<Map.Entry<String, SteveEntity>> iterator = activeSteves.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, SteveEntity> entry = iterator.next();
+            SteveEntity steve = entry.getValue();
+            if (!steve.isAlive() || steve.isRemoved()) {
+                iterator.remove();
+                stevesByUUID.remove(steve.getUUID());
+                SteveMod.LOGGER.info("Cleaned up Steve: {}", entry.getKey());
+            }
+        }
     }
 
     public void clearAllSteves() {
@@ -197,7 +268,8 @@ public class SteveManager {
             steve.discard();
         }
         activeSteves.clear();
-        stevesByUUID.clear();    }
+        stevesByUUID.clear();
+    }
 
     public Collection<SteveEntity> getAllSteves() {
         return Collections.unmodifiableCollection(activeSteves.values());
@@ -210,20 +282,4 @@ public class SteveManager {
     public int getActiveCount() {
         return activeSteves.size();
     }
-
-    public void tick(ServerLevel level) {
-        // Clean up dead or removed Steves
-        Iterator<Map.Entry<String, SteveEntity>> iterator = activeSteves.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, SteveEntity> entry = iterator.next();
-            SteveEntity steve = entry.getValue();
-            
-            if (!steve.isAlive() || steve.isRemoved()) {
-                iterator.remove();
-                stevesByUUID.remove(steve.getUUID());
-                SteveMod.LOGGER.info("Cleaned up Steve: {}", entry.getKey());
-            }
-        }
-    }
 }
-

--- a/src/main/java/com/steve/ai/entity/SteveManager.java
+++ b/src/main/java/com/steve/ai/entity/SteveManager.java
@@ -36,7 +36,14 @@ public class SteveManager {
      *
      * <p>Re-adopting the same instance is a no-op (idempotent).
      *
-     * @return the adopted instance, or null if it was discarded as a duplicate
+     * <p>A duplicate newcomer that is rejected is returned as null and is
+     * NOT discarded here: during an {@code EntityJoinLevelEvent} the entity
+     * has not entered the world yet, so {@code ServerEventHandler} cancels
+     * the join instead. {@code discard()} stays for instances that are
+     * already in the world (the NBT-vs-fresh replacement below) and for
+     * {@link #removeSteve(String, MinecraftServer)}.
+     *
+     * @return the adopted instance, or null if it was rejected as a duplicate
      */
     public SteveEntity adopt(SteveEntity steve) {
         if (steve == null) {
@@ -63,12 +70,11 @@ public class SteveManager {
                 activeSteves.remove(name);
                 stevesByUUID.remove(existing.getUUID());
             } else {
-                // Duplicate bot with the same name: discard the newcomer. Its
-                // NBT-inventory equals the survivor's, so suppress the drop to
-                // avoid an item-dupe exploit.
-                steve.setSuppressInventoryDrop(true);
-                steve.discard();
-                SteveMod.LOGGER.info("Dedup: discarded duplicate Steve '{}' ({}) - another live instance exists",
+                // Duplicate bot with the same name: reject the newcomer. It has
+                // not entered the world yet during an EntityJoinLevelEvent, so
+                // the join is canceled (see ServerEventHandler) instead of a
+                // discard that would drop the (identical, duplicated) contents.
+                SteveMod.LOGGER.info("Dedup: rejected duplicate Steve '{}' ({}) - another live instance exists",
                         name, steve.getUUID());
                 return null;
             }
@@ -180,6 +186,12 @@ public class SteveManager {
      * because a bot loaded from NBT may exist in a chunk without being
      * tracked in the maps (e.g. after the dedup auto-spawn regression).
      *
+     * <p>Note: {@link ServerLevel#getAllEntities()} only enumerates entities
+     * in <em>loaded</em> chunks. A bot whose chunk is unloaded is not visited
+     * by the sweep and will be re-adopted (and thus re-appear in the
+     * registry) via {@link #adopt(SteveEntity)} when its chunk loads again;
+     * run this command again after the chunk is loaded to remove it.
+     *
      * <p>When several same-named instances exist in the world (a bug), only
      * the tracked instance may drop its inventory; every other duplicate has
      * its inventory drop suppressed so the (identical, duplicated) contents
@@ -201,12 +213,12 @@ public class SteveManager {
                     }
                 }
             }
-            SteveEntity tracked = activeSteves.get(name);
+            SteveEntity trackedInWorldSweep = activeSteves.get(name);
             for (SteveEntity steve : matches) {
                 if (!steve.isAlive() || steve.isRemoved()) {
                     continue;
                 }
-                if (steve != tracked) {
+                if (steve != trackedInWorldSweep) {
                     // Same-named duplicate: dropping its (identical) contents
                     // would dupe items, so suppress the drop for non-tracked
                     // copies. The tracked instance keeps the normal drop.

--- a/src/main/java/com/steve/ai/entity/SteveWorldData.java
+++ b/src/main/java/com/steve/ai/entity/SteveWorldData.java
@@ -1,0 +1,39 @@
+package com.steve.ai.entity;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.saveddata.SavedData;
+
+/**
+ * World-persisted marker that controls the one-time spawn of the default
+ * bots. Stored in the overworld's {@link net.minecraft.world.level.storage.DimensionDataStorage},
+ * so it survives chunk unloads and player logouts - unlike a static JVM flag,
+ * which was reset on every player logout and caused default bots to be
+ * re-spawned (and duplicated) on each login.
+ */
+public class SteveWorldData extends SavedData {
+    public static final String DATA_NAME = "steve_default_bots_spawned";
+    private static final String TAG_DEFAULT_BOTS_SPAWNED = "DefaultBotsSpawned";
+
+    private boolean defaultBotsSpawned;
+
+    public static SteveWorldData load(CompoundTag tag) {
+        SteveWorldData data = new SteveWorldData();
+        data.defaultBotsSpawned = tag.getBoolean(TAG_DEFAULT_BOTS_SPAWNED);
+        return data;
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag tag) {
+        tag.putBoolean(TAG_DEFAULT_BOTS_SPAWNED, this.defaultBotsSpawned);
+        return tag;
+    }
+
+    public boolean hasDefaultBotsSpawned() {
+        return this.defaultBotsSpawned;
+    }
+
+    public void markDefaultBotsSpawned() {
+        this.defaultBotsSpawned = true;
+        this.setDirty();
+    }
+}

--- a/src/main/java/com/steve/ai/event/ServerEventHandler.java
+++ b/src/main/java/com/steve/ai/event/ServerEventHandler.java
@@ -3,11 +3,12 @@ package com.steve.ai.event;
 import com.steve.ai.SteveMod;
 import com.steve.ai.entity.SteveEntity;
 import com.steve.ai.entity.SteveManager;
-import com.steve.ai.memory.StructureRegistry;
 import com.steve.ai.memory.VisionScanner;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.EntityLeaveLevelEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
@@ -19,13 +20,34 @@ public class ServerEventHandler {
     private static boolean stevesSpawned = false;
 
     /**
+     * Register every Steve that enters the world (fresh spawn, chunk load,
+     * dimension change) with the manager. Server-side only: client copies
+     * must not be tracked. Dedup of world-loaded duplicates happens here too.
+     */
+    @SubscribeEvent
+    public static void onEntityJoinLevel(EntityJoinLevelEvent event) {
+        if (event.getLevel().isClientSide()) {
+            return;
+        }
+        if (event.getEntity() instanceof SteveEntity steve) {
+            SteveMod.getSteveManager().adopt(steve);
+        }
+    }
+
+    /**
      * Drop the vision cache entry when a Steve leaves the level
      * (despawn, removal, dimension change) to avoid memory leaks.
+     * On a chunk unload also untrack it so the registry does not hold
+     * dead references; the bot is re-adopted when its chunk loads again.
      */
     @SubscribeEvent
     public static void onEntityLeaveLevel(EntityLeaveLevelEvent event) {
         if (event.getEntity() instanceof SteveEntity steve) {
             VisionScanner.forget(steve);
+            if (!event.getLevel().isClientSide()
+                    && steve.getRemovalReason() == Entity.RemovalReason.UNLOADED_TO_CHUNK) {
+                SteveMod.getSteveManager().onSteveUnload(steve);
+            }
         }
     }
 
@@ -42,38 +64,33 @@ public class ServerEventHandler {
         if (event.getEntity() instanceof ServerPlayer player) {
             ServerLevel level = (ServerLevel) player.level();
             SteveManager manager = SteveMod.getSteveManager();
-            if (!stevesSpawned) {                manager.clearAllSteves();
-                
-                // Clear structure registry for fresh spatial awareness
-                StructureRegistry.clear();
-                
-                // Then, remove ALL SteveEntity instances from the world (including ones loaded from NBT)
-                int removedCount = 0;
-                for (var entity : level.getAllEntities()) {
-                    if (entity instanceof SteveEntity) {
-                        entity.discard();
-                        removedCount++;
-                    }
-                }                Vec3 playerPos = player.position();
+            if (!stevesSpawned) {
+                // World-loaded Steves are already adopted by onEntityJoinLevel
+                // and keep their NBT state (inventory, memory). Spawn the
+                // default bots only for names that are not taken anywhere.
+                Vec3 playerPos = player.position();
                 Vec3 lookVec = player.getLookAngle();
-                
+
                 String[] names = {"Steve", "Alex", "Bob", "Charlie"};
-                
+
                 for (int i = 0; i < 4; i++) {
+                    if (manager.getSteve(names[i]) != null) {
+                        continue;
+                    }
                     double offsetX = lookVec.x * 5 + (lookVec.z * (i - 1.5) * 2);
                     double offsetZ = lookVec.z * 5 + (-lookVec.x * (i - 1.5) * 2);
-                    
+
                     Vec3 spawnPos = new Vec3(
                         playerPos.x + offsetX,
                         playerPos.y,
                         playerPos.z + offsetZ
                     );
-                    
-                    SteveEntity steve = manager.spawnSteve(level, spawnPos, names[i]);
-                    if (steve != null) {                    }
+
+                    manager.spawnSteve(level, spawnPos, names[i]);
                 }
-                
-                stevesSpawned = true;            }
+
+                stevesSpawned = true;
+            }
         }
     }
 

--- a/src/main/java/com/steve/ai/event/ServerEventHandler.java
+++ b/src/main/java/com/steve/ai/event/ServerEventHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.EntityLeaveLevelEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -35,19 +36,31 @@ public class ServerEventHandler {
     }
 
     /**
-     * Drop the vision cache entry when a Steve leaves the level
-     * (despawn, removal, dimension change) to avoid memory leaks.
-     * On a chunk unload also untrack it so the registry does not hold
-     * dead references; the bot is re-adopted when its chunk loads again.
+     * Drop the vision cache entry when a Steve leaves the level (despawn,
+     * removal, dimension change) to avoid memory leaks. Untrack it from the
+     * registries for every removal reason except a dimension change: a
+     * CHANGED_DIMENSION bot is still alive (just in another level) and is
+     * re-adopted idempotently when it joins the new level.
      */
     @SubscribeEvent
     public static void onEntityLeaveLevel(EntityLeaveLevelEvent event) {
         if (event.getEntity() instanceof SteveEntity steve) {
             VisionScanner.forget(steve);
             if (!event.getLevel().isClientSide()
-                    && steve.getRemovalReason() == Entity.RemovalReason.UNLOADED_TO_CHUNK) {
+                    && steve.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION) {
                 SteveMod.getSteveManager().onSteveUnload(steve);
             }
+        }
+    }
+
+    /**
+     * Periodic safety net: the manager cleans dead/removed Steve entries that
+     * were not untracked by any leave-level event.
+     */
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            SteveMod.getSteveManager().tick();
         }
     }
 

--- a/src/main/java/com/steve/ai/event/ServerEventHandler.java
+++ b/src/main/java/com/steve/ai/event/ServerEventHandler.java
@@ -3,6 +3,7 @@ package com.steve.ai.event;
 import com.steve.ai.SteveMod;
 import com.steve.ai.entity.SteveEntity;
 import com.steve.ai.entity.SteveManager;
+import com.steve.ai.entity.SteveWorldData;
 import com.steve.ai.memory.VisionScanner;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -18,12 +19,13 @@ import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(modid = SteveMod.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ServerEventHandler {
-    private static boolean stevesSpawned = false;
 
     /**
      * Register every Steve that enters the world (fresh spawn, chunk load,
      * dimension change) with the manager. Server-side only: client copies
-     * must not be tracked. Dedup of world-loaded duplicates happens here too.
+     * must not be tracked. Dedup of world-loaded duplicates happens here too:
+     * adopt() rejects a duplicate that has not entered the world yet, and
+     * canceling the event keeps it from being added at all.
      */
     @SubscribeEvent
     public static void onEntityJoinLevel(EntityJoinLevelEvent event) {
@@ -31,7 +33,9 @@ public class ServerEventHandler {
             return;
         }
         if (event.getEntity() instanceof SteveEntity steve) {
-            SteveMod.getSteveManager().adopt(steve);
+            if (SteveMod.getSteveManager().adopt(steve) == null) {
+                event.setCanceled(true);
+            }
         }
     }
 
@@ -77,19 +81,23 @@ public class ServerEventHandler {
         if (event.getEntity() instanceof ServerPlayer player) {
             ServerLevel level = (ServerLevel) player.level();
             SteveManager manager = SteveMod.getSteveManager();
-            if (!stevesSpawned) {
+            // The "default bots already spawned" marker lives in the world's
+            // SavedData, so it survives chunk unloads and player logouts. The
+            // default bots are spawned only on the very first world start -
+            // never re-spawned on a later login (bug #9).
+            SteveWorldData worldData = getWorldData(level);
+            if (!worldData.hasDefaultBotsSpawned()) {
                 // World-loaded Steves are already adopted by onEntityJoinLevel
-                // and keep their NBT state (inventory, memory). Spawn the
-                // default bots only for names that are not taken anywhere.
+                // and keep their NBT state (inventory, memory). spawnSteve()
+                // skips names that already exist in the registry or in a
+                // loaded chunk, so no duplicate is created over a world bot
+                // that sits in a loaded chunk either.
                 Vec3 playerPos = player.position();
                 Vec3 lookVec = player.getLookAngle();
 
                 String[] names = {"Steve", "Alex", "Bob", "Charlie"};
 
                 for (int i = 0; i < 4; i++) {
-                    if (manager.getSteve(names[i]) != null) {
-                        continue;
-                    }
                     double offsetX = lookVec.x * 5 + (lookVec.z * (i - 1.5) * 2);
                     double offsetZ = lookVec.z * 5 + (-lookVec.x * (i - 1.5) * 2);
 
@@ -102,14 +110,20 @@ public class ServerEventHandler {
                     manager.spawnSteve(level, spawnPos, names[i]);
                 }
 
-                stevesSpawned = true;
+                worldData.markDefaultBotsSpawned();
             }
         }
     }
 
-    @SubscribeEvent
-    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-        stevesSpawned = false;
+    /**
+     * Returns the persistent {@link SteveWorldData} of the world the given
+     * level belongs to. The overworld's data storage is used so the marker
+     * is shared across dimensions. The entry is created on first access.
+     */
+    private static SteveWorldData getWorldData(ServerLevel level) {
+        ServerLevel overworld = level.getServer() != null ? level.getServer().overworld() : level;
+        return overworld.getDataStorage().computeIfAbsent(
+            SteveWorldData::load, SteveWorldData::new, SteveWorldData.DATA_NAME);
     }
 }
 

--- a/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
@@ -1,19 +1,12 @@
 package com.steve.ai.entity;
 
-import net.minecraft.SharedConstants;
-import net.minecraft.WorldVersion;
+import com.steve.ai.testutil.AbstractMinecraftTest;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.server.Bootstrap;
-import net.minecraft.server.packs.PackType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.storage.DataVersion;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,38 +14,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * Unit tests for SteveInventory (add/merge/capacity/NBT logic).
  *
  * Vanilla Items require Minecraft's registries, which are initialized via
- * SharedConstants.setVersion + Bootstrap.bootStrap() before the tests.
+ * SharedConstants.setVersion + Bootstrap.bootStrap() in AbstractMinecraftTest.
  */
-class SteveInventoryTest {
-
-    @BeforeAll
-    static void bootstrap() {
-        try {
-            SharedConstants.setVersion(new WorldVersion() {
-                @Override
-                public String getName() { return "1.20.1"; }
-                @Override
-                public String getId() { return "1.20.1"; }
-                @Override
-                public DataVersion getDataVersion() { return new DataVersion(3465); }
-                @Override
-                public int getProtocolVersion() { return 765; }
-                @Override
-                public int getPackVersion(PackType type) { return 15; }
-                @Override
-                public Date getBuildTime() { return new Date(0); }
-                @Override
-                public boolean isStable() { return true; }
-            });
-        } catch (IllegalStateException e) {
-            // Version already set by another test class in the same JVM.
-        }
-        try {
-            Bootstrap.bootStrap();
-        } catch (IllegalStateException e) {
-            // Already bootstrapped by another test class in the same JVM.
-        }
-    }
+class SteveInventoryTest extends AbstractMinecraftTest {
 
     @Test
     void addItemMergesIntoExistingStack() {

--- a/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveInventoryTest.java
@@ -27,23 +27,31 @@ class SteveInventoryTest {
 
     @BeforeAll
     static void bootstrap() {
-        SharedConstants.setVersion(new WorldVersion() {
-            @Override
-            public String getName() { return "1.20.1"; }
-            @Override
-            public String getId() { return "1.20.1"; }
-            @Override
-            public DataVersion getDataVersion() { return new DataVersion(3465); }
-            @Override
-            public int getProtocolVersion() { return 765; }
-            @Override
-            public int getPackVersion(PackType type) { return 15; }
-            @Override
-            public Date getBuildTime() { return new Date(0); }
-            @Override
-            public boolean isStable() { return true; }
-        });
-        Bootstrap.bootStrap();
+        try {
+            SharedConstants.setVersion(new WorldVersion() {
+                @Override
+                public String getName() { return "1.20.1"; }
+                @Override
+                public String getId() { return "1.20.1"; }
+                @Override
+                public DataVersion getDataVersion() { return new DataVersion(3465); }
+                @Override
+                public int getProtocolVersion() { return 765; }
+                @Override
+                public int getPackVersion(PackType type) { return 15; }
+                @Override
+                public Date getBuildTime() { return new Date(0); }
+                @Override
+                public boolean isStable() { return true; }
+            });
+        } catch (IllegalStateException e) {
+            // Version already set by another test class in the same JVM.
+        }
+        try {
+            Bootstrap.bootStrap();
+        } catch (IllegalStateException e) {
+            // Already bootstrapped by another test class in the same JVM.
+        }
     }
 
     @Test

--- a/src/test/java/com/steve/ai/entity/SteveManagerTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveManagerTest.java
@@ -1,18 +1,11 @@
 package com.steve.ai.entity;
 
-import net.minecraft.SharedConstants;
-import net.minecraft.WorldVersion;
-import net.minecraft.server.Bootstrap;
+import com.steve.ai.testutil.AbstractMinecraftTest;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.packs.PackType;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.storage.DataVersion;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,39 +16,10 @@ import static org.mockito.Mockito.*;
  * Unit tests for the SteveManager lifecycle: dedup on adopt, NBT-loaded
  * preference, registry cleanup (leave/tick) and removeSteve world sweep.
  *
- * Minecraft's registries are bootstrapped like in SteveInventoryTest; entity
+ * Minecraft's registries are bootstrapped in AbstractMinecraftTest; entity
  * interactions are mocked (no running game server is needed).
  */
-class SteveManagerTest {
-
-    @BeforeAll
-    static void bootstrap() {
-        try {
-            SharedConstants.setVersion(new WorldVersion() {
-                @Override
-                public String getName() { return "1.20.1"; }
-                @Override
-                public String getId() { return "1.20.1"; }
-                @Override
-                public DataVersion getDataVersion() { return new DataVersion(3465); }
-                @Override
-                public int getProtocolVersion() { return 765; }
-                @Override
-                public int getPackVersion(PackType type) { return 15; }
-                @Override
-                public Date getBuildTime() { return new Date(0); }
-                @Override
-                public boolean isStable() { return true; }
-            });
-        } catch (IllegalStateException e) {
-            // Version already set by another test class in the same JVM.
-        }
-        try {
-            Bootstrap.bootStrap();
-        } catch (IllegalStateException e) {
-            // Already bootstrapped by another test class in the same JVM.
-        }
-    }
+class SteveManagerTest extends AbstractMinecraftTest {
 
     private static SteveEntity mockSteve(String name, UUID uuid) {
         SteveEntity steve = mock(SteveEntity.class);
@@ -97,7 +61,7 @@ class SteveManagerTest {
     }
 
     @Test
-    void adoptDiscardsDuplicateNewcomer() {
+    void adoptRejectsDuplicateNewcomer() {
         SteveManager manager = new SteveManager();
         SteveEntity original = mockSteve("Steve", UUID.randomUUID());
         SteveEntity duplicate = mockSteve("Steve", UUID.randomUUID());
@@ -107,8 +71,10 @@ class SteveManagerTest {
 
         assertSame(original, manager.getSteve("Steve"));
         assertNull(manager.getSteve(duplicate.getUUID()));
-        verify(duplicate).setSuppressInventoryDrop(true);
-        verify(duplicate).discard();
+        // The rejected duplicate has not entered the world yet - the caller
+        // (ServerEventHandler) cancels the join event instead of discarding.
+        verify(duplicate, never()).setSuppressInventoryDrop(true);
+        verify(duplicate, never()).discard();
         verify(original, never()).discard();
     }
 
@@ -146,8 +112,8 @@ class SteveManagerTest {
         assertNull(manager.adopt(b));
 
         assertSame(a, manager.getSteve("Steve"));
-        verify(b).setSuppressInventoryDrop(true);
-        verify(b).discard();
+        verify(b, never()).setSuppressInventoryDrop(true);
+        verify(b, never()).discard();
         verify(a, never()).discard();
     }
 

--- a/src/test/java/com/steve/ai/entity/SteveManagerTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveManagerTest.java
@@ -1,0 +1,337 @@
+package com.steve.ai.entity;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.WorldVersion;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.DataVersion;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the SteveManager lifecycle: dedup on adopt, NBT-loaded
+ * preference, registry cleanup (leave/tick) and removeSteve world sweep.
+ *
+ * Minecraft's registries are bootstrapped like in SteveInventoryTest; entity
+ * interactions are mocked (no running game server is needed).
+ */
+class SteveManagerTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        try {
+            SharedConstants.setVersion(new WorldVersion() {
+                @Override
+                public String getName() { return "1.20.1"; }
+                @Override
+                public String getId() { return "1.20.1"; }
+                @Override
+                public DataVersion getDataVersion() { return new DataVersion(3465); }
+                @Override
+                public int getProtocolVersion() { return 765; }
+                @Override
+                public int getPackVersion(PackType type) { return 15; }
+                @Override
+                public Date getBuildTime() { return new Date(0); }
+                @Override
+                public boolean isStable() { return true; }
+            });
+        } catch (IllegalStateException e) {
+            // Version already set by another test class in the same JVM.
+        }
+        try {
+            Bootstrap.bootStrap();
+        } catch (IllegalStateException e) {
+            // Already bootstrapped by another test class in the same JVM.
+        }
+    }
+
+    private static SteveEntity mockSteve(String name, UUID uuid) {
+        SteveEntity steve = mock(SteveEntity.class);
+        when(steve.getSteveName()).thenReturn(name);
+        when(steve.getUUID()).thenReturn(uuid);
+        when(steve.isAlive()).thenReturn(true);
+        when(steve.isRemoved()).thenReturn(false);
+        when(steve.isLoadedFromNbt()).thenReturn(false);
+        doNothing().when(steve).discard();
+        return steve;
+    }
+
+    // ==================== adopt / dedup ====================
+
+    @Test
+    void adoptRegistersNewSteve() {
+        SteveManager manager = new SteveManager();
+        UUID uuid = UUID.randomUUID();
+        SteveEntity steve = mockSteve("Steve", uuid);
+
+        SteveEntity adopted = manager.adopt(steve);
+
+        assertSame(steve, adopted);
+        assertSame(steve, manager.getSteve("Steve"));
+        assertSame(steve, manager.getSteve(uuid));
+        assertEquals(1, manager.getActiveCount());
+    }
+
+    @Test
+    void adoptIsIdempotentForSameInstance() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Steve", UUID.randomUUID());
+
+        assertSame(steve, manager.adopt(steve));
+        assertSame(steve, manager.adopt(steve));
+
+        assertEquals(1, manager.getActiveCount());
+        verify(steve, never()).discard();
+    }
+
+    @Test
+    void adoptDiscardsDuplicateNewcomer() {
+        SteveManager manager = new SteveManager();
+        SteveEntity original = mockSteve("Steve", UUID.randomUUID());
+        SteveEntity duplicate = mockSteve("Steve", UUID.randomUUID());
+
+        assertSame(original, manager.adopt(original));
+        assertNull(manager.adopt(duplicate));
+
+        assertSame(original, manager.getSteve("Steve"));
+        assertNull(manager.getSteve(duplicate.getUUID()));
+        verify(duplicate).setSuppressInventoryDrop(true);
+        verify(duplicate).discard();
+        verify(original, never()).discard();
+    }
+
+    @Test
+    void adoptPrefersNbtLoadedOverFreshSpawn() {
+        SteveManager manager = new SteveManager();
+        SteveEntity fresh = mockSteve("Steve", UUID.randomUUID());
+        UUID originalUuid = UUID.randomUUID();
+        SteveEntity original = mockSteve("Steve", originalUuid);
+        when(original.isLoadedFromNbt()).thenReturn(true);
+
+        // The fresh spawn registers first (the original lives in an unloaded chunk).
+        assertSame(fresh, manager.adopt(fresh));
+        // When the original's chunk loads, the NBT-loaded bot must win.
+        assertSame(original, manager.adopt(original));
+
+        assertSame(original, manager.getSteve("Steve"));
+        assertSame(original, manager.getSteve(originalUuid));
+        assertNull(manager.getSteve(fresh.getUUID()));
+        verify(fresh).setSuppressInventoryDrop(true);
+        verify(fresh).discard();
+        verify(original, never()).discard();
+    }
+
+    @Test
+    void adoptKeepsFirstNbtLoadedInstanceOnDoubleNbtDedup() {
+        SteveManager manager = new SteveManager();
+        UUID uuidA = UUID.randomUUID();
+        SteveEntity a = mockSteve("Steve", uuidA);
+        when(a.isLoadedFromNbt()).thenReturn(true);
+        SteveEntity b = mockSteve("Steve", UUID.randomUUID());
+        when(b.isLoadedFromNbt()).thenReturn(true);
+
+        assertSame(a, manager.adopt(a));
+        assertNull(manager.adopt(b));
+
+        assertSame(a, manager.getSteve("Steve"));
+        verify(b).setSuppressInventoryDrop(true);
+        verify(b).discard();
+        verify(a, never()).discard();
+    }
+
+    @Test
+    void adoptReplacesStaleDeadEntry() {
+        SteveManager manager = new SteveManager();
+        SteveEntity stale = mockSteve("Steve", UUID.randomUUID());
+        when(stale.isAlive()).thenReturn(false);
+        SteveEntity fresh = mockSteve("Steve", UUID.randomUUID());
+
+        assertSame(stale, manager.adopt(stale));
+        assertSame(fresh, manager.adopt(fresh));
+
+        assertSame(fresh, manager.getSteve("Steve"));
+        assertNull(manager.getSteve(stale.getUUID()));
+        verify(stale, never()).discard();
+    }
+
+    @Test
+    void adoptRejectsNull() {
+        SteveManager manager = new SteveManager();
+        assertNull(manager.adopt(null));
+        assertEquals(0, manager.getActiveCount());
+    }
+
+    // ==================== onSteveUnload ====================
+
+    @Test
+    void onSteveUnloadRemovesTrackedEntry() {
+        SteveManager manager = new SteveManager();
+        UUID uuid = UUID.randomUUID();
+        SteveEntity steve = mockSteve("Steve", uuid);
+        manager.adopt(steve);
+
+        manager.onSteveUnload(steve);
+
+        assertNull(manager.getSteve("Steve"));
+        assertNull(manager.getSteve(uuid));
+        assertEquals(0, manager.getActiveCount());
+    }
+
+    @Test
+    void onSteveUnloadIgnoresUntrackedEntity() {
+        SteveManager manager = new SteveManager();
+        SteveEntity tracked = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(tracked);
+
+        // A different same-named instance leaves - the registry must stay.
+        SteveEntity other = mockSteve("Steve", UUID.randomUUID());
+        manager.onSteveUnload(other);
+
+        assertSame(tracked, manager.getSteve("Steve"));
+        assertEquals(1, manager.getActiveCount());
+    }
+
+    @Test
+    void onSteveUnloadToleratesNull() {
+        SteveManager manager = new SteveManager();
+        assertDoesNotThrow(() -> manager.onSteveUnload(null));
+    }
+
+    // ==================== tick ====================
+
+    @Test
+    void tickCleansDeadSteves() {
+        SteveManager manager = new SteveManager();
+        SteveEntity alive = mockSteve("Steve", UUID.randomUUID());
+        SteveEntity dead = mockSteve("Alex", UUID.randomUUID());
+        when(dead.isAlive()).thenReturn(false);
+        manager.adopt(alive);
+        manager.adopt(dead);
+
+        manager.tick();
+
+        assertSame(alive, manager.getSteve("Steve"));
+        assertNull(manager.getSteve("Alex"));
+        assertEquals(1, manager.getActiveCount());
+    }
+
+    @Test
+    void tickCleansRemovedSteves() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(steve);
+        when(steve.isRemoved()).thenReturn(true);
+
+        manager.tick();
+
+        assertEquals(0, manager.getActiveCount());
+    }
+
+    @Test
+    void tickKeepsLiveSteves() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(steve);
+
+        manager.tick();
+
+        assertEquals(1, manager.getActiveCount());
+        verify(steve, never()).discard();
+    }
+
+    // ==================== removeSteve(String, MinecraftServer) ====================
+
+    @Test
+    void removeSteveSweepsAllWorldMatchesAndRegistry() {
+        SteveManager manager = new SteveManager();
+        SteveEntity tracked = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(tracked);
+
+        UUID uuid2 = UUID.randomUUID();
+        SteveEntity worldBot = mockSteve("Steve", uuid2);
+        ServerLevel level = mock(ServerLevel.class);
+        when(level.getAllEntities()).thenReturn(List.of(tracked, worldBot));
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getAllLevels()).thenReturn(List.of(level));
+
+        assertTrue(manager.removeSteve("Steve", server));
+
+        verify(tracked).discard();
+        verify(worldBot).discard();
+        assertNull(manager.getSteve("Steve"));
+        assertNull(manager.getSteve(uuid2));
+        assertEquals(0, manager.getActiveCount());
+    }
+
+    @Test
+    void removeSteveSuppressesInventoryDropForDuplicatesOnly() {
+        SteveManager manager = new SteveManager();
+        SteveEntity tracked = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(tracked);
+
+        SteveEntity duplicate = mockSteve("Steve", UUID.randomUUID());
+        ServerLevel level = mock(ServerLevel.class);
+        when(level.getAllEntities()).thenReturn(List.of(tracked, duplicate));
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getAllLevels()).thenReturn(List.of(level));
+
+        manager.removeSteve("Steve", server);
+
+        // The tracked instance keeps its normal inventory drop; the duplicate's drop is suppressed.
+        verify(tracked, never()).setSuppressInventoryDrop(true);
+        verify(duplicate).setSuppressInventoryDrop(true);
+        verify(duplicate).discard();
+    }
+
+    @Test
+    void removeSteveSkipsDeadOrRemovedEntities() {
+        SteveManager manager = new SteveManager();
+        SteveEntity tracked = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(tracked);
+
+        SteveEntity dead = mockSteve("Steve", UUID.randomUUID());
+        when(dead.isAlive()).thenReturn(false);
+        SteveEntity removed = mockSteve("Steve", UUID.randomUUID());
+        when(removed.isRemoved()).thenReturn(true);
+
+        ServerLevel level = mock(ServerLevel.class);
+        when(level.getAllEntities()).thenReturn(List.of(tracked, dead, removed));
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getAllLevels()).thenReturn(List.of(level));
+
+        manager.removeSteve("Steve", server);
+
+        verify(tracked).discard();
+        verify(dead, never()).discard();
+        verify(removed, never()).discard();
+    }
+
+    @Test
+    void removeSteveReturnsFalseForUnknownName() {
+        SteveManager manager = new SteveManager();
+        assertFalse(manager.removeSteve("Nobody", null));
+        assertFalse(manager.removeSteve(null, null));
+    }
+
+    @Test
+    void removeSteveHandlesNullServer() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(steve);
+
+        assertTrue(manager.removeSteve("Steve", null));
+        assertEquals(0, manager.getActiveCount());
+    }
+}

--- a/src/test/java/com/steve/ai/entity/SteveWorldDataTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveWorldDataTest.java
@@ -1,0 +1,42 @@
+package com.steve.ai.entity;
+
+import com.steve.ai.testutil.AbstractMinecraftTest;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SteveWorldDataTest extends AbstractMinecraftTest {
+
+    @Test
+    void newDataHasBotsNotSpawned() {
+        SteveWorldData data = new SteveWorldData();
+        assertFalse(data.hasDefaultBotsSpawned());
+    }
+
+    @Test
+    void markFlagsAsSpawned() {
+        SteveWorldData data = new SteveWorldData();
+        data.markDefaultBotsSpawned();
+        assertTrue(data.hasDefaultBotsSpawned());
+    }
+
+    @Test
+    void saveLoadRoundTripPreservesFlag() {
+        SteveWorldData data = new SteveWorldData();
+        data.markDefaultBotsSpawned();
+
+        CompoundTag tag = new CompoundTag();
+        data.save(tag);
+
+        SteveWorldData loaded = SteveWorldData.load(tag);
+        assertTrue(loaded.hasDefaultBotsSpawned());
+    }
+
+    @Test
+    void loadDefaultsToFalse() {
+        SteveWorldData loaded = SteveWorldData.load(new CompoundTag());
+        assertFalse(loaded.hasDefaultBotsSpawned());
+    }
+}

--- a/src/test/java/com/steve/ai/testutil/AbstractMinecraftTest.java
+++ b/src/test/java/com/steve/ai/testutil/AbstractMinecraftTest.java
@@ -1,0 +1,55 @@
+package com.steve.ai.testutil;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.WorldVersion;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.world.level.storage.DataVersion;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Date;
+
+/**
+ * Base class for tests that need the Minecraft registries. Bootstraps the
+ * game with a single {@link WorldVersion} (1.20.1, protocol 763) and calls
+ * {@link Bootstrap#bootStrap()} exactly once per test class. Subclasses do
+ * not need to duplicate the setup; the bootstrapping is idempotent in case
+ * several test classes run in the same JVM.
+ */
+public abstract class AbstractMinecraftTest {
+
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        try {
+            SharedConstants.setVersion(new WorldVersion() {
+                @Override
+                public String getName() { return "1.20.1"; }
+
+                @Override
+                public String getId() { return "1.20.1"; }
+
+                @Override
+                public DataVersion getDataVersion() { return new DataVersion(3465); }
+
+                @Override
+                public int getProtocolVersion() { return 763; }
+
+                @Override
+                public int getPackVersion(PackType type) { return 15; }
+
+                @Override
+                public Date getBuildTime() { return new Date(0); }
+
+                @Override
+                public boolean isStable() { return true; }
+            });
+        } catch (IllegalStateException e) {
+            // Version already set by another test class in the same JVM.
+        }
+        try {
+            Bootstrap.bootStrap();
+        } catch (IllegalStateException e) {
+            // Already bootstrapped by another test class in the same JVM.
+        }
+    }
+}


### PR DESCRIPTION
Реализация #9: Баг: боты дублируются после перезахода в игру; remove находит только один экземпляр

Автоматический PR от steve-pipeline. Ревью: kimi-k2.7 + CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшено управление сущностями Steve при загрузке, удалении и смене измерений.
  * Предотвращено появление дубликатов Steve, включая корректный приоритет сохранённых экземпляров.
  * При удалении дубликатов предотвращено повторное выпадение инвентаря.
  * Добавлена автоматическая очистка неактуальных или удалённых сущностей.

* **Тесты**
  * Расширено покрытие сценариев регистрации, дедупликации, выгрузки и удаления Steve.
  * Повышена стабильность тестов при повторной инициализации Minecraft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->