### PR TITLE
fix: case-insensitive Steve names (issue #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ Desktop.ini
 # Misc
 *.log
 
+# Python
+__pycache__/
+*.pyc
+
 # JDK
 jdk-17.0.2.jdk/
 /logs/

--- a/docs/superpowers/plans/2026-08-20-issue-4-case-insensitive-steve-names.md
+++ b/docs/superpowers/plans/2026-08-20-issue-4-case-insensitive-steve-names.md
@@ -229,7 +229,8 @@ Replace that transition with:
 
             stay_resp = rcon.command("steve tell BOB стоп")
             print(f"  steve tell BOB стоп -> {stay_resp!r}")
-            if "BOB stopped" not in stay_resp and "Bob stopped" not in stay_resp:
+            # The dispatcher replies using the canonical bot name, e.g. "Bob stopped".
+            if "stopped" not in stay_resp.lower() or "bob" not in stay_resp.lower():
                 print("  [FAIL] case-insensitive tell did not stop Bob")
                 return 1
 
@@ -241,7 +242,8 @@ Replace that transition with:
 
             stop_resp = rcon.command("steve stop BOB")
             print(f"  steve stop BOB -> {stop_resp!r}")
-            if "BOB stopped" not in stop_resp and "Bob stopped" not in stop_resp:
+            # stopSteve returns "Stopped Steve: " + the supplied argument name.
+            if "stopped" not in stop_resp.lower() or "bob" not in stop_resp.lower():
                 print("  [FAIL] case-insensitive stop did not stop Bob")
                 return 1
 

--- a/docs/superpowers/plans/2026-08-20-issue-4-case-insensitive-steve-names.md
+++ b/docs/superpowers/plans/2026-08-20-issue-4-case-insensitive-steve-names.md
@@ -1,0 +1,310 @@
+# Issue #4 — Case-insensitive Steve names Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all `/steve` commands that accept a Steve name match bots regardless of case (`/steve tell STEVE ...`, `/steve tell steve ...`, `/steve tell Steve ...` behave identically) and add behavior tests proving it.
+
+**Architecture:** Keep canonical names unchanged in `SteveManager.activeSteves` so `/steve list` and chat feedback preserve the player-supplied casing. Introduce a single private case-insensitive lookup helper used by every code path that resolves a name to an entity: `getSteve(String)`, `adopt`, `spawnSteve`, `removeSteve`, and `onSteveUnload`. The world sweep in `removeSteve` and `findSteveInLevel` also compare with `equalsIgnoreCase`. Because the active Steve count is tiny (≤10), a linear scan is sufficient and avoids the complexity of a parallel normalized map.
+
+**Tech Stack:** Java 17, Forge 1.20.1, JUnit 5, Mockito, Gradle. Python 3 behavior tests using RCON.
+
+**Spec:** GitHub issue #4 in `pravets/Steve` — "Имена ботов в командах должны учитываться регистронезависимо".
+
+## Global Constraints
+
+- Branch from `master`; one PR = one feature; do not commit to `master`.
+- Commit identity for `pravets/*` repos: `Iosif Pravets <i@pravets.ru>`.
+- TDD: failing test first, then minimal implementation, then pass.
+- No bundled unrelated changes; do not refactor beyond what the fix requires.
+- Preserve existing public method signatures and field names.
+- Behavior tests must run against a headless Forge server via RCON; reuse the existing `scripts/behavior/behavior_test.py` harness.
+
+---
+
+### Task 1: Add case-insensitive name lookup to SteveManager
+
+**Files:**
+- Modify: `src/main/java/com/steve/ai/entity/SteveManager.java`
+
+**Interfaces:**
+- Consumes: existing `Map<String, SteveEntity> activeSteves` keyed by canonical (player-supplied) name.
+- Produces: private helper `SteveEntity findByNameIgnoreCase(String name)` returning the tracked entity whose key matches `name.equalsIgnoreCase`, or `null`. All existing public methods keep their signatures; only internal lookups change.
+
+- [ ] **Step 1: Open `src/main/java/com/steve/ai/entity/SteveManager.java`**
+
+- [ ] **Step 2: Add a private helper after the constructors**
+
+```java
+    private SteveEntity findByNameIgnoreCase(String name) {
+        if (name == null) {
+            return null;
+        }
+        for (Map.Entry<String, SteveEntity> entry : activeSteves.entrySet()) {
+            if (name.equalsIgnoreCase(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+```
+
+- [ ] **Step 3: Replace `activeSteves.get(name)` lookups with `findByNameIgnoreCase(name)`**
+
+Update these locations in order:
+
+1. In `adopt(SteveEntity steve)` (around line 53):
+   - Change `SteveEntity existing = activeSteves.get(name);` to `SteveEntity existing = findByNameIgnoreCase(name);`
+
+2. In `spawnSteve(ServerLevel, Vec3, String)`:
+   - Change `if (activeSteves.containsKey(name)) {` to `if (findByNameIgnoreCase(name) != null) {`
+   - Change `if (activeSteves.get(name) == steve && steve.isAlive()) {` to `if (findByNameIgnoreCase(name) == steve && steve.isAlive()) {`
+
+3. In `findSteveInLevel(ServerLevel, String)` (around line 167):
+   - Change `&& name.equals(steve.getSteveName())` to `&& name.equalsIgnoreCase(steve.getSteveName())`
+
+4. In `getSteve(String name)` (around line 175):
+   - Change `return name == null ? null : activeSteves.get(name);` to `return name == null ? null : findByNameIgnoreCase(name);`
+
+5. In `removeSteve(String, MinecraftServer)` (around line 216):
+   - Change `SteveEntity trackedInWorldSweep = activeSteves.get(name);` to `SteveEntity trackedInWorldSweep = findByNameIgnoreCase(name);`
+
+6. In `onSteveUnload(SteveEntity)` (around line 251):
+   - Change `SteveEntity tracked = activeSteves.get(name);` to `SteveEntity tracked = findByNameIgnoreCase(name);`
+
+- [ ] **Step 4: Verify the file compiles**
+
+Run: `./gradlew compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/steve/ai/entity/SteveManager.java
+git -c user.name="Iosif Pravets" -c user.email="i@pravets.ru" commit -m "fix(SteveManager): case-insensitive lookup of Steve names
+
+All name-based lookups (getSteve, adopt, spawnSteve, removeSteve,
+onSteveUnload) now match regardless of letter case while preserving
+the canonical casing stored at registration. World sweep uses
+equalsIgnoreCase as well.
+
+Closes #4"
+```
+
+---
+
+### Task 2: Add unit tests for case-insensitive SteveManager behavior
+
+**Files:**
+- Modify: `src/test/java/com/steve/ai/entity/SteveManagerTest.java`
+
+**Interfaces:**
+- Consumes: `mockSteve` helper from `SteveManagerTest`; public `SteveManager` methods updated in Task 1.
+- Produces: new test methods proving case-insensitive behavior for lookup, dedup, spawn guard, remove, and unload.
+
+- [ ] **Step 1: Open `src/test/java/com/steve/ai/entity/SteveManagerTest.java`**
+
+- [ ] **Step 2: Append the following tests at the end of the class, before the closing brace**
+
+```java
+    // ==================== case-insensitive name handling (issue #4) ====================
+
+    @Test
+    void getSteveMatchesIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(steve);
+
+        assertSame(steve, manager.getSteve("Steve"));
+        assertSame(steve, manager.getSteve("steve"));
+        assertSame(steve, manager.getSteve("STEVE"));
+        assertSame(steve, manager.getSteve("StEvE"));
+    }
+
+    @Test
+    void adoptRejectsDuplicateIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity original = mockSteve("Steve", UUID.randomUUID());
+        SteveEntity duplicate = mockSteve("steve", UUID.randomUUID());
+
+        assertSame(original, manager.adopt(original));
+        assertNull(manager.adopt(duplicate));
+
+        assertSame(original, manager.getSteve("Steve"));
+        verify(duplicate, never()).discard();
+    }
+
+    @Test
+    void spawnSteveRejectsDuplicateIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity existing = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(existing);
+
+        ServerLevel level = mock(ServerLevel.class);
+
+        assertNull(manager.spawnSteve(level, new net.minecraft.world.phys.Vec3(0, 0, 0), "steve"));
+        assertNull(manager.spawnSteve(level, new net.minecraft.world.phys.Vec3(0, 0, 0), "STEVE"));
+        assertSame(existing, manager.getSteve("Steve"));
+    }
+
+    @Test
+    void removeSteveMatchesIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Bob", UUID.randomUUID());
+        manager.adopt(steve);
+
+        assertTrue(manager.removeSteve("BOB", null));
+        assertNull(manager.getSteve("Bob"));
+        assertEquals(0, manager.getActiveCount());
+        verify(steve).discard();
+    }
+
+    @Test
+    void onSteveUnloadMatchesIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        UUID uuid = UUID.randomUUID();
+        SteveEntity steve = mockSteve("Alex", uuid);
+        manager.adopt(steve);
+
+        manager.onSteveUnload(steve);
+
+        assertNull(manager.getSteve("alex"));
+        assertNull(manager.getSteve(uuid));
+        assertEquals(0, manager.getActiveCount());
+    }
+```
+
+- [ ] **Step 3: Run only the new tests**
+
+Run: `./gradlew test --tests "com.steve.ai.entity.SteveManagerTest"`
+Expected: all tests pass; specifically the five new case-insensitive tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/test/java/com/steve/ai/entity/SteveManagerTest.java
+git -c user.name="Iosif Pravets" -c user.email="i@pravets.ru" commit -m "test(SteveManager): case-insensitive name lookups
+
+Unit tests covering getSteve, adopt dedup, spawnSteve guard, removeSteve,
+and onSteveUnload with mismatched letter casing.
+
+Relates #4"
+```
+
+---
+
+### Task 3: Extend behavior tests to verify case-insensitive command names
+
+**Files:**
+- Modify: `scripts/behavior/behavior_test.py`
+
+**Interfaces:**
+- Consumes: existing RCON harness, server start/stop, `wait_for`, and the existing Cyrillic + Bob scenarios.
+- Produces: a new scenario that spawns `Bob`, sends `/steve tell BOB стоп`, `/steve tell bob gather 50 wood`, and `/steve stop BOB`, asserting each command resolves to the same bot.
+
+- [ ] **Step 1: Open `scripts/behavior/behavior_test.py`**
+
+- [ ] **Step 2: Insert a new scenario after the cyrillic block and before the original Bob spawn block**
+
+Locate the comment:
+
+```python
+            print("  -> cyrillic names work, invalid name rejected")
+
+            # 1. Spawn Bob
+```
+
+Replace that transition with:
+
+```python
+            print("  -> cyrillic names work, invalid name rejected")
+
+            # 0b. Case-insensitive name handling (issue #4): the canonical
+            # bot is named "Bob", but commands with different casing must
+            # resolve to the same entity.
+            print("Testing case-insensitive Steve names (issue #4)...")
+
+            rcon.command("steve spawn Bob")
+            if not wait_for(log_path, r"[Ss]pawned Steve: Bob", 30, "case-insensitive spawn"):
+                return 1
+
+            stay_resp = rcon.command("steve tell BOB стоп")
+            print(f"  steve tell BOB стоп -> {stay_resp!r}")
+            if "BOB stopped" not in stay_resp and "Bob stopped" not in stay_resp:
+                print("  [FAIL] case-insensitive tell did not stop Bob")
+                return 1
+
+            gather_resp = rcon.command("steve tell bob gather 50 wood")
+            print(f"  steve tell bob gather 50 wood -> {gather_resp!r}")
+            if not wait_for(log_path, r"async planning complete: 1 tasks queued", 120, "case-insensitive task queued"):
+                print("  [FAIL] case-insensitive tell did not queue a task for Bob")
+                return 1
+
+            stop_resp = rcon.command("steve stop BOB")
+            print(f"  steve stop BOB -> {stop_resp!r}")
+            if "BOB stopped" not in stop_resp and "Bob stopped" not in stop_resp:
+                print("  [FAIL] case-insensitive stop did not stop Bob")
+                return 1
+
+            remove_resp = rcon.command("steve remove bob")
+            print(f"  steve remove bob -> {remove_resp!r}")
+            if "Removed Steve" not in remove_resp or "bob" not in remove_resp.lower():
+                print("  [FAIL] case-insensitive remove did not remove Bob")
+                return 1
+            print("  -> case-insensitive names work")
+
+            # 1. Spawn Bob
+```
+
+- [ ] **Step 3: Verify Python syntax**
+
+Run: `python3 -m py_compile scripts/behavior/behavior_test.py`
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/behavior/behavior_test.py
+git -c user.name="Iosif Pravets" -c user.email="i@pravets.ru" commit -m "test(behavior): case-insensitive command names (issue #4)
+
+Add an RCON scenario that drives /steve tell / stop / remove with
+uppercase and lowercase variants of the canonical name 'Bob'.
+
+Relates #4"
+```
+
+---
+
+### Task 4: Run full unit-test suite and verify green baseline
+
+**Files:**
+- None (verification task).
+
+**Interfaces:**
+- Consumes: implementation and tests from Tasks 1–3.
+- Produces: test report confirming no regressions.
+
+- [ ] **Step 1: Run the full unit-test suite**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL, all existing + new tests pass.
+
+- [ ] **Step 2: If any test fails, diagnose and fix**
+
+Use `superpowers:systematic-debugging`. Do not proceed to final review until the suite is green.
+
+- [ ] **Step 3: Commit any fixes**
+
+If no fixes were needed, no commit. If fixes were made, commit with a clear message describing the regression fixed.
+
+---
+
+## Self-Review Checklist
+
+1. **Spec coverage:** Does the plan address every requirement from issue #4?
+   - [x] `getSteve` is case-insensitive.
+   - [x] Spawn duplicate check is case-insensitive.
+   - [x] `/steve tell`, `/steve tp`, `/steve stop`, `/steve remove`, `/steve inventory` work because they all route through `SteveManager.getSteve` or `spawnSteve`/`removeSteve`.
+   - [x] Behavior tests added.
+2. **Placeholder scan:** No TODO/TBD; every step contains exact code or exact commands.
+3. **Type consistency:** `findByNameIgnoreCase` returns `SteveEntity`; signatures of public methods unchanged.
+4. **No unrelated changes:** Only `SteveManager.java`, `SteveManagerTest.java`, and `behavior_test.py` are touched.

--- a/scripts/behavior/behavior_test.py
+++ b/scripts/behavior/behavior_test.py
@@ -30,7 +30,10 @@ RCON_PASSWORD = "steve_test"
 
 
 class RCON:
+    """Minimal Minecraft RCON client with terminator-packet draining."""
+
     def __init__(self, host="127.0.0.1", port=RCON_PORT, password=RCON_PASSWORD):
+        """Connect to host:port and authenticate with password."""
         self.sock = socket.create_connection((host, port), timeout=60)
         self.request_id = 1
         self._buf = b""
@@ -63,6 +66,7 @@ class RCON:
             # Otherwise discard empty terminator and continue.
 
     def _send(self, ptype, body):
+        """Send a raw RCON packet and return the response packet."""
         rid = self.request_id
         self.request_id += 1
         payload = struct.pack("<ii", rid, ptype) + body.encode() + b"\x00\x00"
@@ -86,6 +90,7 @@ class RCON:
                 raise ConnectionError("Timed out waiting for RCON response")
 
     def _recv_exact(self, n):
+        """Read exactly n bytes from the socket (kept for compatibility)."""
         data = b""
         while len(data) < n:
             chunk = self.sock.recv(n - len(data))
@@ -95,6 +100,7 @@ class RCON:
         return data
 
     def _auth(self, password):
+        """Authenticate with the RCON server."""
         rid, ptype, _ = self._send(3, password)
         if rid == -1 or ptype != 2:
             raise ConnectionError(f"RCON auth failed (id={rid}, type={ptype})")
@@ -103,14 +109,17 @@ class RCON:
         time.sleep(1.0)
 
     def command(self, cmd):
+        """Send a command and return its response body."""
         rid, ptype, body = self._send(2, cmd)
         return body
 
     def close(self):
+        """Close the RCON connection."""
         self.sock.close()
 
 
 def start_server(workdir, jar_path, log_path):
+    """Launch the headless Forge server and redirect all output to log_path."""
     with open(log_path, "wb") as log:
         proc = subprocess.Popen(
             ["java", "-Xmx2G", "@libraries/net/minecraftforge/forge/1.20.1-47.2.0/unix_args.txt", "nogui"],
@@ -119,6 +128,13 @@ def start_server(workdir, jar_path, log_path):
 
 
 def wait_for(log_path, pattern, timeout, label):
+    """Wait until log_path contains a line matching regex pattern.
+
+    Reads incrementally from the last position to avoid re-scanning the whole
+    log on every poll.
+
+    Returns True on match, False if the timeout expires.
+    """
     regex = re.compile(pattern)
     deadline = time.time() + timeout
     last = 0
@@ -136,6 +152,7 @@ def wait_for(log_path, pattern, timeout, label):
 
 
 def main():
+    """Run the headless Forge server behavior test and return an exit code."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--dir", required=True, help="server directory")
     ap.add_argument("--jar", required=True, help="path to steve mod jar")

--- a/scripts/behavior/behavior_test.py
+++ b/scripts/behavior/behavior_test.py
@@ -33,30 +33,57 @@ class RCON:
     def __init__(self, host="127.0.0.1", port=RCON_PORT, password=RCON_PASSWORD):
         self.sock = socket.create_connection((host, port), timeout=60)
         self.request_id = 1
+        self._buf = b""
         self._auth(password)
+
+    def _read_packet(self):
+        """Parse one complete packet from ``self._buf`` if available."""
+        if len(self._buf) < 4:
+            return None
+        length = struct.unpack("<i", self._buf[:4])[0]
+        if len(self._buf) < 4 + length:
+            return None
+        pkt = self._buf[4:4 + length]
+        self._buf = self._buf[4 + length:]
+        r, t = struct.unpack("<ii", pkt[:8])
+        body = pkt[8:].rstrip(b"\x00").decode(errors="replace")
+        return r, t, body
+
+    def _drain_empty_packets(self):
+        """Discard empty SERVERDATA_RESPONSE_VALUE terminator packets."""
+        while True:
+            pkt = self._read_packet()
+            if pkt is None:
+                return
+            r, t, body = pkt
+            if t != 0 or body:
+                # Not an empty terminator; put it back and stop draining.
+                self._buf = struct.pack("<i", 10) + struct.pack("<ii", r, t) + body.encode() + b"\x00\x00" + self._buf
+                return
+            # Otherwise discard empty terminator and continue.
 
     def _send(self, ptype, body):
         rid = self.request_id
         self.request_id += 1
         payload = struct.pack("<ii", rid, ptype) + body.encode() + b"\x00\x00"
         self.sock.sendall(struct.pack("<i", len(payload)) + payload)
-        # Forge answers each request with exactly one packet - read until it
-        # is fully buffered. (recv_exact-style reads deadlocked on the body,
-        # so keep it simple: one recv loop, one packet per request.)
         self.sock.settimeout(30)
-        buf = b""
+        # Command responses can leave empty terminator packets behind. Make
+        # sure the next response read starts on a real packet, not on a
+        # leftover terminator.
+        if ptype == 2:
+            self._drain_empty_packets()
         while True:
-            chunk = self.sock.recv(4096)
-            if not chunk:
-                raise ConnectionError("RCON connection closed while reading response")
-            buf += chunk
-            if len(buf) >= 4:
-                length = struct.unpack("<i", buf[:4])[0]
-                if len(buf) >= 4 + length:
-                    pkt = buf[4:4 + length]
-                    r, t = struct.unpack("<ii", pkt[:8])
-                    body = pkt[8:].rstrip(b"\x00").decode(errors="replace")
-                    return r, t, body
+            pkt = self._read_packet()
+            if pkt is not None:
+                return pkt
+            try:
+                chunk = self.sock.recv(4096)
+                if not chunk:
+                    raise ConnectionError("RCON connection closed while reading response")
+                self._buf += chunk
+            except socket.timeout:
+                raise ConnectionError("Timed out waiting for RCON response")
 
     def _recv_exact(self, n):
         data = b""
@@ -220,13 +247,15 @@ def main():
             if not wait_for(log_path, r"Spawned Steve: Bob", 30, "spawn"):
                 return 1
 
-            # Extract Bob's UUID and actual spawn position for the /tp
+            # Extract Bob's UUID and actual spawn position for the /tp.
+            # There may be an earlier case-insensitive spawn, so always use the
+            # *last* occurrence in the log (the one we just spawned).
             with open(log_path, "r", errors="replace") as f:
                 log_text = f.read()
             uuid_m = None
-            m = re.search(r"[Ss]pawned Steve: Bob with UUID ([0-9a-f-]+)", log_text)
-            if m:
-                uuid_m = m.group(1)
+            uuid_matches = re.findall(r"[Ss]pawned Steve: Bob with UUID ([0-9a-f-]+)", log_text)
+            if uuid_matches:
+                uuid_m = uuid_matches[-1]
             if not uuid_m:
                 print("  [FAIL] Bob UUID not found in log")
                 return 1
@@ -239,12 +268,11 @@ def main():
             #    spawn, so anything within 9 chunks ticks even without our
             #    force-loading. y=4 = flat surface: teleporting high up makes
             #    the bot fall for ages and stalls the 1-core runner.
-            spawn_pos = re.search(r"[Ss]pawned Steve: Bob with UUID [0-9a-f-]+ at \(([-\d.]+), ([-\d.]+), ([-\d.]+)\)", log_text)
-            if not spawn_pos:
+            spawn_pos_matches = re.findall(r"[Ss]pawned Steve: Bob with UUID [0-9a-f-]+ at \(([-\d.]+), ([-\d.]+), ([-\d.]+)\)", log_text)
+            if not spawn_pos_matches:
                 print("  [FAIL] Bob spawn position not found in log")
                 return 1
-            spawn_x = float(spawn_pos.group(1))
-            spawn_z = float(spawn_pos.group(3))
+            spawn_x, _, spawn_z = map(float, spawn_pos_matches[-1])
             far_x = int(spawn_x) + 10 * 16 + 8  # +10 chunks east, block coords
             print(f"Teleporting Bob from spawn ({spawn_x:.0f}, {spawn_z:.0f}) to ({far_x}, 4, 0)...")
             rcon.command(f"tp {uuid_m} {far_x} 4 0")

--- a/scripts/behavior/behavior_test.py
+++ b/scripts/behavior/behavior_test.py
@@ -179,6 +179,41 @@ def main():
                     return 1
             print("  -> cyrillic names work, invalid name rejected")
 
+            # 0b. Case-insensitive name handling (issue #4): the canonical
+            # bot is named "Bob", but commands with different casing must
+            # resolve to the same entity.
+            print("Testing case-insensitive Steve names (issue #4)...")
+
+            rcon.command("steve spawn Bob")
+            if not wait_for(log_path, r"[Ss]pawned Steve: Bob", 30, "case-insensitive spawn"):
+                return 1
+
+            stay_resp = rcon.command("steve tell BOB стоп")
+            print(f"  steve tell BOB стоп -> {stay_resp!r}")
+            # The dispatcher replies with the canonical bot name.
+            if "stopped" not in stay_resp.lower() or "bob" not in stay_resp.lower():
+                print("  [FAIL] case-insensitive tell did not stop Bob")
+                return 1
+
+            gather_resp = rcon.command("steve tell bob gather 50 wood")
+            print(f"  steve tell bob gather 50 wood -> {gather_resp!r}")
+            if not wait_for(log_path, r"async planning complete: 1 tasks queued", 120, "case-insensitive task queued"):
+                print("  [FAIL] case-insensitive tell did not queue a task for Bob")
+                return 1
+
+            stop_resp = rcon.command("steve stop BOB")
+            print(f"  steve stop BOB -> {stop_resp!r}")
+            if "stopped" not in stop_resp.lower() or "bob" not in stop_resp.lower():
+                print("  [FAIL] case-insensitive stop did not stop Bob")
+                return 1
+
+            remove_resp = rcon.command("steve remove bob")
+            print(f"  steve remove bob -> {remove_resp!r}")
+            if "removed" not in remove_resp.lower() or "bob" not in remove_resp.lower():
+                print("  [FAIL] case-insensitive remove did not remove Bob")
+                return 1
+            print("  -> case-insensitive names work")
+
             # 1. Spawn Bob
             print("Spawning Bob...")
             rcon.command("steve spawn Bob")

--- a/src/main/java/com/steve/ai/entity/SteveManager.java
+++ b/src/main/java/com/steve/ai/entity/SteveManager.java
@@ -22,16 +22,21 @@ public class SteveManager {
         this.stevesByUUID = new ConcurrentHashMap<>();
     }
 
-    private SteveEntity findByNameIgnoreCase(String name) {
+    private Map.Entry<String, SteveEntity> findEntryByNameIgnoreCase(String name) {
         if (name == null) {
             return null;
         }
         for (Map.Entry<String, SteveEntity> entry : activeSteves.entrySet()) {
             if (name.equalsIgnoreCase(entry.getKey())) {
-                return entry.getValue();
+                return entry;
             }
         }
         return null;
+    }
+
+    private SteveEntity findByNameIgnoreCase(String name) {
+        Map.Entry<String, SteveEntity> entry = findEntryByNameIgnoreCase(name);
+        return entry != null ? entry.getValue() : null;
     }
 
     /**
@@ -62,14 +67,16 @@ public class SteveManager {
             return null;
         }
         String name = requireNonNull(steve.getSteveName(), "Steve name must not be null");
-        SteveEntity existing = findByNameIgnoreCase(name);
+        Map.Entry<String, SteveEntity> existingEntry = findEntryByNameIgnoreCase(name);
+        SteveEntity existing = existingEntry != null ? existingEntry.getValue() : null;
         if (existing != null) {
             if (existing == steve) {
                 return steve;
             }
+            String existingKey = existingEntry.getKey();
             if (!existing.isAlive() || existing.isRemoved()) {
                 // Stale registry entry (e.g. survivor of a crash) - replace it
-                activeSteves.remove(name);
+                activeSteves.remove(existingKey);
                 stevesByUUID.remove(existing.getUUID());
             } else if (steve.isLoadedFromNbt() && !existing.isLoadedFromNbt()) {
                 // The newcomer is the real bot loaded from NBT; the survivor is
@@ -79,7 +86,7 @@ public class SteveManager {
                 existing.discard();
                 SteveMod.LOGGER.info("Dedup: replaced fresh duplicate '{}' ({}) with NBT-loaded original ({})",
                         name, existing.getUUID(), steve.getUUID());
-                activeSteves.remove(name);
+                activeSteves.remove(existingKey);
                 stevesByUUID.remove(existing.getUUID());
             } else {
                 // Duplicate bot with the same name: reject the newcomer. It has
@@ -220,7 +227,7 @@ public class SteveManager {
             List<SteveEntity> matches = new ArrayList<>();
             for (ServerLevel level : server.getAllLevels()) {
                 for (Entity entity : level.getAllEntities()) {
-                    if (entity instanceof SteveEntity steve && name.equals(steve.getSteveName())) {
+                    if (entity instanceof SteveEntity steve && name.equalsIgnoreCase(steve.getSteveName())) {
                         matches.add(steve);
                     }
                 }
@@ -240,9 +247,10 @@ public class SteveManager {
                 removed = true;
             }
         }
-        SteveEntity tracked = activeSteves.remove(name);
-        if (tracked != null) {
-            stevesByUUID.remove(tracked.getUUID());
+        Map.Entry<String, SteveEntity> trackedEntry = findEntryByNameIgnoreCase(name);
+        if (trackedEntry != null) {
+            activeSteves.remove(trackedEntry.getKey());
+            stevesByUUID.remove(trackedEntry.getValue().getUUID());
             removed = true;
         }
         return removed;
@@ -260,9 +268,9 @@ public class SteveManager {
             return;
         }
         String name = requireNonNull(steve.getSteveName(), "Steve name must not be null");
-        SteveEntity tracked = findByNameIgnoreCase(name);
-        if (tracked == steve) {
-            activeSteves.remove(name);
+        Map.Entry<String, SteveEntity> trackedEntry = findEntryByNameIgnoreCase(name);
+        if (trackedEntry != null && trackedEntry.getValue() == steve) {
+            activeSteves.remove(trackedEntry.getKey());
             SteveMod.LOGGER.info("Steve '{}' left the world, removed from registry", name);
         }
         stevesByUUID.remove(steve.getUUID());

--- a/src/main/java/com/steve/ai/entity/SteveManager.java
+++ b/src/main/java/com/steve/ai/entity/SteveManager.java
@@ -22,6 +22,18 @@ public class SteveManager {
         this.stevesByUUID = new ConcurrentHashMap<>();
     }
 
+    private SteveEntity findByNameIgnoreCase(String name) {
+        if (name == null) {
+            return null;
+        }
+        for (Map.Entry<String, SteveEntity> entry : activeSteves.entrySet()) {
+            if (name.equalsIgnoreCase(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
     /**
      * Registers a SteveEntity that entered the world (fresh spawn or loaded
      * from a chunk / NBT). If the name is already taken by another live
@@ -50,7 +62,7 @@ public class SteveManager {
             return null;
         }
         String name = requireNonNull(steve.getSteveName(), "Steve name must not be null");
-        SteveEntity existing = activeSteves.get(name);
+        SteveEntity existing = findByNameIgnoreCase(name);
         if (existing != null) {
             if (existing == steve) {
                 return steve;
@@ -88,7 +100,7 @@ public class SteveManager {
         name = requireNonNull(name, "Steve name must not be null");
         SteveMod.LOGGER.info("Current active Steves: {}", activeSteves.size());
 
-        if (activeSteves.containsKey(name)) {
+        if (findByNameIgnoreCase(name) != null) {
             SteveMod.LOGGER.warn("Steve name '{}' already exists", name);
             return null;
         }
@@ -130,7 +142,7 @@ public class SteveManager {
                 // exact instance; a same-named Steve may have been loaded
                 // concurrently and won the dedup, in which case steve was
                 // already discarded.
-                if (activeSteves.get(name) == steve && steve.isAlive()) {
+                if (findByNameIgnoreCase(name) == steve && steve.isAlive()) {
                     SteveMod.LOGGER.info("Successfully spawned Steve: {} with UUID {} at {}", name, steve.getUUID(), position);
                     return steve;
                 } else {
@@ -164,7 +176,7 @@ public class SteveManager {
         }
         for (Entity entity : level.getAllEntities()) {
             if (entity instanceof SteveEntity steve
-                    && name.equals(steve.getSteveName())
+                    && name.equalsIgnoreCase(steve.getSteveName())
                     && steve.isAlive() && !steve.isRemoved()) {
                 return steve;
             }
@@ -173,7 +185,7 @@ public class SteveManager {
     }
 
     public SteveEntity getSteve(String name) {
-        return name == null ? null : activeSteves.get(name);
+        return name == null ? null : findByNameIgnoreCase(name);
     }
 
     public SteveEntity getSteve(UUID uuid) {
@@ -213,7 +225,7 @@ public class SteveManager {
                     }
                 }
             }
-            SteveEntity trackedInWorldSweep = activeSteves.get(name);
+            SteveEntity trackedInWorldSweep = findByNameIgnoreCase(name);
             for (SteveEntity steve : matches) {
                 if (!steve.isAlive() || steve.isRemoved()) {
                     continue;
@@ -248,7 +260,7 @@ public class SteveManager {
             return;
         }
         String name = requireNonNull(steve.getSteveName(), "Steve name must not be null");
-        SteveEntity tracked = activeSteves.get(name);
+        SteveEntity tracked = findByNameIgnoreCase(name);
         if (tracked == steve) {
             activeSteves.remove(name);
             SteveMod.LOGGER.info("Steve '{}' left the world, removed from registry", name);

--- a/src/main/java/com/steve/ai/entity/SteveManager.java
+++ b/src/main/java/com/steve/ai/entity/SteveManager.java
@@ -22,6 +22,13 @@ public class SteveManager {
         this.stevesByUUID = new ConcurrentHashMap<>();
     }
 
+    /**
+     * Finds the registry entry whose canonical name matches the given name
+     * ignoring case.
+     *
+     * @param name the name to look up, may be null
+     * @return the matching {@code Map.Entry} (canonical name + entity), or null
+     */
     private Map.Entry<String, SteveEntity> findEntryByNameIgnoreCase(String name) {
         if (name == null) {
             return null;
@@ -34,6 +41,14 @@ public class SteveManager {
         return null;
     }
 
+    /**
+     * Returns the tracked Steve whose canonical name matches the given name
+     * ignoring case.
+     *
+     * @param name the name to look up, may be null
+     * @return the matching entity, or null if no Steve is tracked under a
+     *         case-insensitive match
+     */
     private SteveEntity findByNameIgnoreCase(String name) {
         Map.Entry<String, SteveEntity> entry = findEntryByNameIgnoreCase(name);
         return entry != null ? entry.getValue() : null;
@@ -103,6 +118,15 @@ public class SteveManager {
         return steve;
     }
 
+    /**
+     * Spawns a new Steve at the given position if no live Steve with the same
+     * name (ignoring case) is already tracked or present in the level.
+     *
+     * @param level    the level to spawn in
+     * @param position the spawn position
+     * @param name     the desired Steve name
+     * @return the spawned entity, or null if a duplicate exists or limits are reached
+     */
     public SteveEntity spawnSteve(ServerLevel level, Vec3 position, String name) {
         name = requireNonNull(name, "Steve name must not be null");
         SteveMod.LOGGER.info("Current active Steves: {}", activeSteves.size());
@@ -191,10 +215,22 @@ public class SteveManager {
         return null;
     }
 
+    /**
+     * Looks up a tracked Steve by name, ignoring case.
+     *
+     * @param name the Steve name to look up
+     * @return the tracked entity, or null if no match is found
+     */
     public SteveEntity getSteve(String name) {
         return name == null ? null : findByNameIgnoreCase(name);
     }
 
+    /**
+     * Looks up a tracked Steve by UUID.
+     *
+     * @param uuid the UUID to look up
+     * @return the tracked entity, or null if no match is found
+     */
     public SteveEntity getSteve(UUID uuid) {
         return uuid == null ? null : stevesByUUID.get(uuid);
     }

--- a/src/test/java/com/steve/ai/entity/SteveManagerTest.java
+++ b/src/test/java/com/steve/ai/entity/SteveManagerTest.java
@@ -300,4 +300,67 @@ class SteveManagerTest extends AbstractMinecraftTest {
         assertTrue(manager.removeSteve("Steve", null));
         assertEquals(0, manager.getActiveCount());
     }
+
+    // ==================== case-insensitive name handling ====================
+
+    @Test
+    void getSteveMatchesIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity steve = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(steve);
+
+        assertSame(steve, manager.getSteve("steve"));
+        assertSame(steve, manager.getSteve("STEVE"));
+        assertSame(steve, manager.getSteve("StEvE"));
+    }
+
+    @Test
+    void adoptRejectsDuplicateDifferingOnlyInCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity original = mockSteve("Steve", UUID.randomUUID());
+        SteveEntity duplicate = mockSteve("steve", UUID.randomUUID());
+
+        assertSame(original, manager.adopt(original));
+        assertNull(manager.adopt(duplicate));
+
+        assertSame(original, manager.getSteve("Steve"));
+        assertEquals(1, manager.getActiveCount());
+    }
+
+    @Test
+    void removeSteveMatchesTrackedAndWorldEntitiesIgnoringCase() {
+        SteveManager manager = new SteveManager();
+        SteveEntity tracked = mockSteve("Steve", UUID.randomUUID());
+        manager.adopt(tracked);
+
+        UUID worldUuid = UUID.randomUUID();
+        SteveEntity worldBot = mockSteve("STEVE", worldUuid);
+        ServerLevel level = mock(ServerLevel.class);
+        when(level.getAllEntities()).thenReturn(List.of(tracked, worldBot));
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getAllLevels()).thenReturn(List.of(level));
+
+        assertTrue(manager.removeSteve("steve", server));
+
+        verify(tracked).discard();
+        verify(worldBot).discard();
+        assertNull(manager.getSteve("Steve"));
+        assertNull(manager.getSteve(worldUuid));
+        assertEquals(0, manager.getActiveCount());
+    }
+
+    @Test
+    void onSteveUnloadRemovesEntryWhenNameCasingDiffersFromKey() {
+        SteveManager manager = new SteveManager();
+        UUID uuid = UUID.randomUUID();
+        SteveEntity steve = mockSteve("Steve", uuid);
+        manager.adopt(steve);
+
+        when(steve.getSteveName()).thenReturn("steve");
+        manager.onSteveUnload(steve);
+
+        assertNull(manager.getSteve("Steve"));
+        assertNull(manager.getSteve(uuid));
+        assertEquals(0, manager.getActiveCount());
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Команды `/steve` теперь распознают имена без учёта регистра.
  * Steve с именами, отличающимися только регистром, корректно определяется как дубликат.
  * Операции поиска, остановки, удаления и выгрузки работают независимо от регистра введённого имени.
  * Повышена стабильность обработки ответов RCON-команд.

* **Тесты**
  * Добавлены автоматические проверки регистронезависимой работы команд и управления Steve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->