### PR TITLE
fix(action): planning-level timeout watchdog for async LLM calls

### DIFF
--- a/src/main/java/com/steve/ai/action/ActionExecutor.java
+++ b/src/main/java/com/steve/ai/action/ActionExecutor.java
@@ -48,6 +48,8 @@ public class ActionExecutor {
     private CompletableFuture<ResponseParser.ParsedResponse> planningFuture;
     private boolean isPlanning = false;
     private String pendingCommand;  // Store command while planning
+    private int planningStartTick = -1;
+    private static final int PLANNING_CHECK_INTERVAL = 20; // once per second
 
     // NEW: Plugin architecture components
     private final ActionContext actionContext;
@@ -147,6 +149,7 @@ public class ActionExecutor {
             // Store command and start async planning
             this.pendingCommand = command;
             this.isPlanning = true;
+            this.planningStartTick = this.ticksSinceLastAction;
 
             // Send immediate feedback to user
             sendToGUI(steve.getSteveName(), "Thinking...");
@@ -267,6 +270,28 @@ public class ActionExecutor {
                 isPlanning = false;
                 planningFuture = null;
                 pendingCommand = null;
+                planningStartTick = -1;
+            }
+        }
+
+        if (isPlanning && planningStartTick >= 0 &&
+            (ticksSinceLastAction - planningStartTick) % PLANNING_CHECK_INTERVAL == 0 &&
+            (ticksSinceLastAction - planningStartTick) / PLANNING_CHECK_INTERVAL >= 1) {
+
+            int elapsedSeconds = (ticksSinceLastAction - planningStartTick) / 20;
+            if (elapsedSeconds >= SteveConfig.PLANNING_TIMEOUT_SECONDS.get()) {
+                SteveMod.LOGGER.warn("Steve '{}' planning timed out after {}s", steve.getSteveName(), elapsedSeconds);
+                AgentDebugBuffer.log(steve.getSteveName(), "PLAN", "planning timed out after " + elapsedSeconds + "s");
+
+                if (planningFuture != null) {
+                    planningFuture.cancel(true);
+                }
+
+                sendToGUI(steve.getSteveName(), "LLM planning timed out — please try again.");
+                isPlanning = false;
+                planningFuture = null;
+                pendingCommand = null;
+                planningStartTick = -1;
             }
         }
 

--- a/src/main/java/com/steve/ai/action/ActionExecutor.java
+++ b/src/main/java/com/steve/ai/action/ActionExecutor.java
@@ -537,6 +537,17 @@ public class ActionExecutor {
     }
 
     /**
+     * Test-only hook that injects a planning future without starting a real LLM call.
+     * Package-private so unit tests in the same package can set up a stuck-planning scenario.
+     */
+    void setPlanningFutureForTest(CompletableFuture<ResponseParser.ParsedResponse> future, String command) {
+        this.pendingCommand = command;
+        this.isPlanning = true;
+        this.planningFuture = future;
+        this.planningStartTick = this.ticksSinceLastAction;
+    }
+
+    /**
      * Number of tasks waiting in the queue.
      */
     public int getQueuedTaskCount() {

--- a/src/main/java/com/steve/ai/config/SteveConfig.java
+++ b/src/main/java/com/steve/ai/config/SteveConfig.java
@@ -12,6 +12,7 @@ public class SteveConfig {
     public static final ForgeConfigSpec.IntValue MAX_TOKENS;
     public static final ForgeConfigSpec.DoubleValue TEMPERATURE;
     public static final ForgeConfigSpec.IntValue LLM_TIMEOUT_SECONDS;
+    public static final ForgeConfigSpec.IntValue PLANNING_TIMEOUT_SECONDS;
     public static final ForgeConfigSpec.IntValue WORLD_SCAN_RADIUS;
     public static final ForgeConfigSpec.IntValue WORLD_SCAN_STEP;
     public static final ForgeConfigSpec.IntValue WORLD_SCAN_CACHE_TICKS;
@@ -76,6 +77,11 @@ public class SteveConfig {
         LLM_TIMEOUT_SECONDS = builder
             .comment("Per-request timeout in seconds")
             .defineInRange("timeoutSeconds", 60, 5, 300);
+
+        PLANNING_TIMEOUT_SECONDS = builder
+            .comment("Maximum time in seconds the ActionExecutor will wait for async LLM planning to complete.",
+                "This is a safety guard above the per-HTTP-request timeout.")
+            .defineInRange("planningTimeoutSeconds", 75, 5, 600);
 
         builder.pop();
 

--- a/src/main/java/com/steve/ai/llm/async/OpenAICompatibleClient.java
+++ b/src/main/java/com/steve/ai/llm/async/OpenAICompatibleClient.java
@@ -50,6 +50,8 @@ public class OpenAICompatibleClient implements AsyncLLMClient {
         this.jsonMode = jsonMode;
         this.timeout = Duration.ofSeconds(timeoutSeconds);
 
+        // The per-request timeout (connect + response) is applied on each HttpRequest
+        // via .timeout(timeout); the builder-level connectTimeout covers TCP handshake.
         this.httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
             .build();

--- a/src/test/java/com/steve/ai/action/ActionExecutorTest.java
+++ b/src/test/java/com/steve/ai/action/ActionExecutorTest.java
@@ -1,16 +1,61 @@
 package com.steve.ai.action;
 
+import com.steve.ai.config.SteveConfig;
+import com.steve.ai.entity.SteveEntity;
+import com.steve.ai.llm.ResponseParser;
+import com.steve.ai.testutil.AbstractMinecraftTest;
+import com.electronwill.nightconfig.core.CommentedConfig;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test suite for ActionExecutor
  */
-public class ActionExecutorTest {
+class ActionExecutorTest extends AbstractMinecraftTest {
+
+    @BeforeAll
+    static void loadSteveConfig() {
+        CommentedConfig config = CommentedConfig.inMemory();
+        SteveConfig.SPEC.correct(config);
+        SteveConfig.SPEC.acceptConfig(config);
+    }
 
     @Test
-    void testActionExecution() {
-        // TODO: Add test implementation
-        // Example: Test action queue and execution
+    void planningWatchdogResetsStuckPlanning() {
+        // Given a Steve whose level reports not client-side (so GUI messages are skipped)
+        SteveEntity steve = mock(SteveEntity.class);
+        Level level = mock(Level.class);
+        PathNavigation navigation = mock(PathNavigation.class);
+
+        when(level.isClientSide()).thenReturn(false);
+        when(level.players()).thenReturn(Collections.emptyList());
+        when(steve.level()).thenReturn(level);
+        when(steve.getSteveName()).thenReturn("TestSteve");
+        when(steve.getNavigation()).thenReturn(navigation);
+
+        ActionExecutor executor = new ActionExecutor(steve);
+
+        // Replace the planning future with one that never completes
+        CompletableFuture<ResponseParser.ParsedResponse> never = new CompletableFuture<>();
+        executor.setPlanningFutureForTest(never, "chop 5 wood");
+
+        assertTrue(executor.isPlanning());
+
+        // Simulate 80 seconds of ticks (20 ticks/sec). The watchdog checks once per second
+        // and the configured planning timeout is 75 seconds, so this must trigger.
+        for (int i = 0; i < 20 * 80; i++) {
+            executor.tick();
+        }
+
+        assertFalse(executor.isPlanning(), "Planning flag should be reset after timeout");
+        assertTrue(never.isCancelled(), "Stuck future should be cancelled by watchdog");
     }
 }


### PR DESCRIPTION
Fixes #15.

## Problem
`ActionExecutor` could remain in `isPlanning=true` indefinitely if the async planning future never completed, leaving the bot unresponsive.

## Changes
- Added `[llm] planningTimeoutSeconds` config (default 75s).
- Added a tick-based planning watchdog in `ActionExecutor.tick()` that cancels the planning future, resets state, and notifies the player when the timeout is hit.
- Verified HTTP-level connect/request timeouts are already enforced in `OpenAICompatibleClient` and added a clarifying comment.
- Added `ActionExecutorTest` regression test with a mocked never-completing future.

## Verification
- Local `compileJava`: BUILD SUCCESSFUL
- Local `ActionExecutorTest`: 1/1 passing
- CI: full `Build` + `behavior-tests` expected after PR open.

## Commits
- a0d3974 fix(action): planning-level timeout watchdog for async LLM calls
- 93494d6 docs(llm): clarify HTTP connect vs request timeout behavior
- 38536e5 test(action): regression test for planning timeout watchdog