### PR TITLE
fix(action): cancel async planning on stop/stay

### DIFF
--- a/src/main/java/com/steve/ai/action/ActionExecutor.java
+++ b/src/main/java/com/steve/ai/action/ActionExecutor.java
@@ -123,6 +123,7 @@ public class ActionExecutor {
     public void processNaturalLanguageCommand(String command) {
         SteveMod.LOGGER.info("Steve '{}' processing command (async): {}", steve.getSteveName(), command);
 
+        long requestId;
         synchronized (planningLock) {
             // If already planning, ignore new commands
             if (isPlanning) {
@@ -131,30 +132,12 @@ public class ActionExecutor {
                 return;
             }
 
-            // Store command and start async planning
+            // Reserve the planning request atomically with the state check.
             this.pendingCommand = command;
             this.isPlanning = true;
             this.planningStartTick = this.ticksSinceLastAction;
-            long requestId = ++planningRequestSequence;
+            requestId = ++planningRequestSequence;
             this.activePlanningRequestId = requestId;
-
-            try {
-                // Start async LLM call - returns immediately!
-                CompletableFuture<ResponseParser.ParsedResponse> future = getTaskPlanner().planTasksAsync(steve, command);
-                this.planningFuture = future;
-
-                SteveMod.LOGGER.info("Steve '{}' started async planning for: {}", steve.getSteveName(), command);
-            } catch (NoClassDefFoundError e) {
-                SteveMod.LOGGER.error("Failed to initialize AI components", e);
-                sendToGUI(steve.getSteveName(), "Sorry, I'm having trouble with my AI systems!");
-                resetPlanningStateLocked();
-                activePlanningRequestId = ++planningRequestSequence;
-            } catch (Exception e) {
-                SteveMod.LOGGER.error("Error starting async planning", e);
-                sendToGUI(steve.getSteveName(), "Oops, something went wrong!");
-                resetPlanningStateLocked();
-                activePlanningRequestId = ++planningRequestSequence;
-            }
         }
 
         // A new command wakes the Steve up from "stay in place".
@@ -180,6 +163,42 @@ public class ActionExecutor {
 
         // Send immediate feedback to user
         sendToGUI(steve.getSteveName(), "Thinking...");
+
+        // Start async LLM call outside the lock.  The future is published only
+        // if the reserved request is still active; a stop/stay that ran in the
+        // meantime invalidated it and we must abort the now-stale request.
+        CompletableFuture<ResponseParser.ParsedResponse> future;
+        try {
+            future = getTaskPlanner().planTasksAsync(steve, command);
+        } catch (NoClassDefFoundError e) {
+            SteveMod.LOGGER.error("Failed to initialize AI components", e);
+            sendToGUI(steve.getSteveName(), "Sorry, I'm having trouble with my AI systems!");
+            synchronized (planningLock) {
+                resetPlanningStateLocked();
+                activePlanningRequestId = ++planningRequestSequence;
+            }
+            return;
+        } catch (Exception e) {
+            SteveMod.LOGGER.error("Error starting async planning", e);
+            sendToGUI(steve.getSteveName(), "Oops, something went wrong!");
+            synchronized (planningLock) {
+                resetPlanningStateLocked();
+                activePlanningRequestId = ++planningRequestSequence;
+            }
+            return;
+        }
+
+        synchronized (planningLock) {
+            if (activePlanningRequestId == requestId) {
+                this.planningFuture = future;
+                SteveMod.LOGGER.info("Steve '{}' started async planning for: {}", steve.getSteveName(), command);
+            } else {
+                // Request was cancelled between reservation and publication.
+                future.cancel(true);
+                SteveMod.LOGGER.debug("Steve '{}' discarded planning future for cancelled request {}",
+                    steve.getSteveName(), requestId);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/steve/ai/action/ActionExecutor.java
+++ b/src/main/java/com/steve/ai/action/ActionExecutor.java
@@ -18,6 +18,7 @@ import com.steve.ai.plugin.PluginManager;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 /**
  * Executes actions for a Steve entity using the plugin-based action system.
@@ -46,11 +47,15 @@ public class ActionExecutor {
 
     // NEW: Async planning support (non-blocking LLM calls)
     private final Object planningLock = new Object();
-    private CompletableFuture<ResponseParser.ParsedResponse> planningFuture;
+    private Future<ResponseParser.ParsedResponse> planningFuture;
     private boolean isPlanning = false;
     private String pendingCommand;  // Store command while planning
     private int planningStartTick = -1;
     private static final int PLANNING_CHECK_INTERVAL = 20; // once per second
+
+    // NEW: Monotonic request ID so each planning attempt owns its lifecycle atomically
+    private long planningRequestSequence = 0L;
+    private long activePlanningRequestId = 0L;
 
     // NEW: Plugin architecture components
     private final ActionContext actionContext;
@@ -125,6 +130,31 @@ public class ActionExecutor {
                 sendToGUI(steve.getSteveName(), "Hold on, I'm still thinking about the previous command...");
                 return;
             }
+
+            // Store command and start async planning
+            this.pendingCommand = command;
+            this.isPlanning = true;
+            this.planningStartTick = this.ticksSinceLastAction;
+            long requestId = ++planningRequestSequence;
+            this.activePlanningRequestId = requestId;
+
+            try {
+                // Start async LLM call - returns immediately!
+                CompletableFuture<ResponseParser.ParsedResponse> future = getTaskPlanner().planTasksAsync(steve, command);
+                this.planningFuture = future;
+
+                SteveMod.LOGGER.info("Steve '{}' started async planning for: {}", steve.getSteveName(), command);
+            } catch (NoClassDefFoundError e) {
+                SteveMod.LOGGER.error("Failed to initialize AI components", e);
+                sendToGUI(steve.getSteveName(), "Sorry, I'm having trouble with my AI systems!");
+                resetPlanningStateLocked();
+                activePlanningRequestId = ++planningRequestSequence;
+            } catch (Exception e) {
+                SteveMod.LOGGER.error("Error starting async planning", e);
+                sendToGUI(steve.getSteveName(), "Oops, something went wrong!");
+                resetPlanningStateLocked();
+                activePlanningRequestId = ++planningRequestSequence;
+            }
         }
 
         // A new command wakes the Steve up from "stay in place".
@@ -148,44 +178,8 @@ public class ActionExecutor {
             idleFollowAction = null;
         }
 
-        try {
-            synchronized (planningLock) {
-                // Store command and start async planning
-                this.pendingCommand = command;
-                this.isPlanning = true;
-                this.planningStartTick = this.ticksSinceLastAction;
-            }
-
-            // Send immediate feedback to user
-            sendToGUI(steve.getSteveName(), "Thinking...");
-
-            // Start async LLM call - returns immediately!
-            CompletableFuture<ResponseParser.ParsedResponse> future = getTaskPlanner().planTasksAsync(steve, command);
-            synchronized (planningLock) {
-                planningFuture = future;
-            }
-
-            SteveMod.LOGGER.info("Steve '{}' started async planning for: {}", steve.getSteveName(), command);
-
-        } catch (NoClassDefFoundError e) {
-            SteveMod.LOGGER.error("Failed to initialize AI components", e);
-            sendToGUI(steve.getSteveName(), "Sorry, I'm having trouble with my AI systems!");
-            synchronized (planningLock) {
-                isPlanning = false;
-                planningFuture = null;
-                pendingCommand = null;
-                planningStartTick = -1;
-            }
-        } catch (Exception e) {
-            SteveMod.LOGGER.error("Error starting async planning", e);
-            sendToGUI(steve.getSteveName(), "Oops, something went wrong!");
-            synchronized (planningLock) {
-                isPlanning = false;
-                planningFuture = null;
-                pendingCommand = null;
-                planningStartTick = -1;
-            }
-        }
+        // Send immediate feedback to user
+        sendToGUI(steve.getSteveName(), "Thinking...");
     }
 
     /**
@@ -250,18 +244,47 @@ public class ActionExecutor {
         ticksSinceLastAction++;
 
         // Check if async planning is complete (non-blocking check!)
-        CompletableFuture<ResponseParser.ParsedResponse> completedFuture = null;
+        Future<ResponseParser.ParsedResponse> completedFuture = null;
+        long expectedId = 0L;
         synchronized (planningLock) {
             if (isPlanning && planningFuture != null && planningFuture.isDone()) {
                 completedFuture = planningFuture;
+                expectedId = activePlanningRequestId;
             }
         }
 
         if (completedFuture != null) {
+            ResponseParser.ParsedResponse response = null;
+            Exception planningError = null;
             try {
-                ResponseParser.ParsedResponse response = completedFuture.get();
+                response = completedFuture.get();
+            } catch (java.util.concurrent.CancellationException e) {
+                planningError = e;
+            } catch (java.util.concurrent.ExecutionException e) {
+                planningError = e;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                planningError = e;
+            } catch (Exception e) {
+                planningError = e;
+            }
 
-                if (response != null) {
+            synchronized (planningLock) {
+                if (expectedId != activePlanningRequestId) {
+                    // A stop/start race happened while we were waiting for the future:
+                    // this result belongs to an older request, so discard it silently.
+                    SteveMod.LOGGER.debug("Steve '{}' discarding stale planning result for request {}",
+                        steve.getSteveName(), expectedId);
+                    return;
+                }
+
+                if (planningError instanceof java.util.concurrent.CancellationException) {
+                    SteveMod.LOGGER.info("Steve '{}' planning was cancelled", steve.getSteveName());
+                    sendToGUI(steve.getSteveName(), "Planning cancelled.");
+                } else if (planningError != null) {
+                    SteveMod.LOGGER.error("Steve '{}' failed to get planning result", steve.getSteveName(), planningError);
+                    sendToGUI(steve.getSteveName(), "Oops, something went wrong while planning!");
+                } else if (response != null) {
                     currentGoal = response.getPlan();
                     steve.getMemory().setCurrentGoal(currentGoal);
 
@@ -283,19 +306,7 @@ public class ActionExecutor {
                     SteveMod.LOGGER.warn("Steve '{}' async planning returned null response", steve.getSteveName());
                 }
 
-            } catch (java.util.concurrent.CancellationException e) {
-                SteveMod.LOGGER.info("Steve '{}' planning was cancelled", steve.getSteveName());
-                sendToGUI(steve.getSteveName(), "Planning cancelled.");
-            } catch (Exception e) {
-                SteveMod.LOGGER.error("Steve '{}' failed to get planning result", steve.getSteveName(), e);
-                sendToGUI(steve.getSteveName(), "Oops, something went wrong while planning!");
-            } finally {
-                synchronized (planningLock) {
-                    isPlanning = false;
-                    planningFuture = null;
-                    pendingCommand = null;
-                    planningStartTick = -1;
-                }
+                resetPlanningStateLocked();
             }
         }
 
@@ -314,10 +325,8 @@ public class ActionExecutor {
                     }
 
                     sendToGUI(steve.getSteveName(), "LLM planning timed out — please try again.");
-                    isPlanning = false;
-                    planningFuture = null;
-                    pendingCommand = null;
-                    planningStartTick = -1;
+                    resetPlanningStateLocked();
+                    activePlanningRequestId = ++planningRequestSequence;
                 }
             }
         }
@@ -511,12 +520,22 @@ public class ActionExecutor {
                 if (steve.level().isClientSide()) {
                     sendToGUI(steve.getSteveName(), "Planning cancelled.");
                 }
-                isPlanning = false;
-                planningFuture = null;
-                pendingCommand = null;
-                planningStartTick = -1;
+                resetPlanningStateLocked();
+                activePlanningRequestId = ++planningRequestSequence;
             }
         }
+    }
+
+    /**
+     * Clears all planning-related state under planningLock. Does not touch
+     * the request-id generator; callers must bump activePlanningRequestId
+     * separately when invalidating the current request.
+     */
+    private void resetPlanningStateLocked() {
+        isPlanning = false;
+        planningFuture = null;
+        pendingCommand = null;
+        planningStartTick = -1;
     }
 
     /**
@@ -594,12 +613,13 @@ public class ActionExecutor {
      * Test-only hook that injects a planning future without starting a real LLM call.
      * Package-private so unit tests in the same package can set up a stuck-planning scenario.
      */
-    void setPlanningFutureForTest(CompletableFuture<ResponseParser.ParsedResponse> future, String command) {
+    void setPlanningFutureForTest(Future<ResponseParser.ParsedResponse> future, String command) {
         synchronized (planningLock) {
             this.pendingCommand = command;
             this.isPlanning = true;
             this.planningFuture = future;
             this.planningStartTick = this.ticksSinceLastAction;
+            this.activePlanningRequestId = ++planningRequestSequence;
         }
     }
 
@@ -648,4 +668,3 @@ public class ActionExecutor {
         return str.substring(0, maxLength) + "...";
     }
 }
-

--- a/src/main/java/com/steve/ai/action/ActionExecutor.java
+++ b/src/main/java/com/steve/ai/action/ActionExecutor.java
@@ -465,6 +465,29 @@ public class ActionExecutor {
         currentGoal = null;
         // Reset state machine
         stateMachine.reset();
+        cancelPlanning();
+    }
+
+    /**
+     * Cancels an in-progress async LLM planning future and clears all
+     * planning-related state. Called from {@link #stopCurrentAction()} so
+     * stop/stay commands abort planning as well as execution.
+     */
+    private void cancelPlanning() {
+        if (isPlanning || planningFuture != null) {
+            if (planningFuture != null) {
+                planningFuture.cancel(true);
+            }
+            SteveMod.LOGGER.info("Steve '{}' planning cancelled by stop", steve.getSteveName());
+            AgentDebugBuffer.log(steve.getSteveName(), "PLAN", "planning cancelled by stop command");
+            if (steve.level().isClientSide()) {
+                sendToGUI(steve.getSteveName(), "Planning cancelled.");
+            }
+            isPlanning = false;
+            planningFuture = null;
+            pendingCommand = null;
+            planningStartTick = -1;
+        }
     }
 
     /**

--- a/src/main/java/com/steve/ai/action/ActionExecutor.java
+++ b/src/main/java/com/steve/ai/action/ActionExecutor.java
@@ -45,6 +45,7 @@ public class ActionExecutor {
     private volatile boolean staying = false;
 
     // NEW: Async planning support (non-blocking LLM calls)
+    private final Object planningLock = new Object();
     private CompletableFuture<ResponseParser.ParsedResponse> planningFuture;
     private boolean isPlanning = false;
     private String pendingCommand;  // Store command while planning
@@ -117,11 +118,13 @@ public class ActionExecutor {
     public void processNaturalLanguageCommand(String command) {
         SteveMod.LOGGER.info("Steve '{}' processing command (async): {}", steve.getSteveName(), command);
 
-        // If already planning, ignore new commands
-        if (isPlanning) {
-            SteveMod.LOGGER.warn("Steve '{}' is already planning, ignoring command: {}", steve.getSteveName(), command);
-            sendToGUI(steve.getSteveName(), "Hold on, I'm still thinking about the previous command...");
-            return;
+        synchronized (planningLock) {
+            // If already planning, ignore new commands
+            if (isPlanning) {
+                SteveMod.LOGGER.warn("Steve '{}' is already planning, ignoring command: {}", steve.getSteveName(), command);
+                sendToGUI(steve.getSteveName(), "Hold on, I'm still thinking about the previous command...");
+                return;
+            }
         }
 
         // A new command wakes the Steve up from "stay in place".
@@ -146,29 +149,42 @@ public class ActionExecutor {
         }
 
         try {
-            // Store command and start async planning
-            this.pendingCommand = command;
-            this.isPlanning = true;
-            this.planningStartTick = this.ticksSinceLastAction;
+            synchronized (planningLock) {
+                // Store command and start async planning
+                this.pendingCommand = command;
+                this.isPlanning = true;
+                this.planningStartTick = this.ticksSinceLastAction;
+            }
 
             // Send immediate feedback to user
             sendToGUI(steve.getSteveName(), "Thinking...");
 
             // Start async LLM call - returns immediately!
-            planningFuture = getTaskPlanner().planTasksAsync(steve, command);
+            CompletableFuture<ResponseParser.ParsedResponse> future = getTaskPlanner().planTasksAsync(steve, command);
+            synchronized (planningLock) {
+                planningFuture = future;
+            }
 
             SteveMod.LOGGER.info("Steve '{}' started async planning for: {}", steve.getSteveName(), command);
 
         } catch (NoClassDefFoundError e) {
             SteveMod.LOGGER.error("Failed to initialize AI components", e);
             sendToGUI(steve.getSteveName(), "Sorry, I'm having trouble with my AI systems!");
-            isPlanning = false;
-            planningFuture = null;
+            synchronized (planningLock) {
+                isPlanning = false;
+                planningFuture = null;
+                pendingCommand = null;
+                planningStartTick = -1;
+            }
         } catch (Exception e) {
             SteveMod.LOGGER.error("Error starting async planning", e);
             sendToGUI(steve.getSteveName(), "Oops, something went wrong!");
-            isPlanning = false;
-            planningFuture = null;
+            synchronized (planningLock) {
+                isPlanning = false;
+                planningFuture = null;
+                pendingCommand = null;
+                planningStartTick = -1;
+            }
         }
     }
 
@@ -234,9 +250,16 @@ public class ActionExecutor {
         ticksSinceLastAction++;
 
         // Check if async planning is complete (non-blocking check!)
-        if (isPlanning && planningFuture != null && planningFuture.isDone()) {
+        CompletableFuture<ResponseParser.ParsedResponse> completedFuture = null;
+        synchronized (planningLock) {
+            if (isPlanning && planningFuture != null && planningFuture.isDone()) {
+                completedFuture = planningFuture;
+            }
+        }
+
+        if (completedFuture != null) {
             try {
-                ResponseParser.ParsedResponse response = planningFuture.get();
+                ResponseParser.ParsedResponse response = completedFuture.get();
 
                 if (response != null) {
                     currentGoal = response.getPlan();
@@ -267,31 +290,35 @@ public class ActionExecutor {
                 SteveMod.LOGGER.error("Steve '{}' failed to get planning result", steve.getSteveName(), e);
                 sendToGUI(steve.getSteveName(), "Oops, something went wrong while planning!");
             } finally {
-                isPlanning = false;
-                planningFuture = null;
-                pendingCommand = null;
-                planningStartTick = -1;
+                synchronized (planningLock) {
+                    isPlanning = false;
+                    planningFuture = null;
+                    pendingCommand = null;
+                    planningStartTick = -1;
+                }
             }
         }
 
-        if (isPlanning && planningStartTick >= 0 &&
-            (ticksSinceLastAction - planningStartTick) % PLANNING_CHECK_INTERVAL == 0 &&
-            (ticksSinceLastAction - planningStartTick) / PLANNING_CHECK_INTERVAL >= 1) {
+        synchronized (planningLock) {
+            if (isPlanning && planningStartTick >= 0 &&
+                (ticksSinceLastAction - planningStartTick) % PLANNING_CHECK_INTERVAL == 0 &&
+                (ticksSinceLastAction - planningStartTick) / PLANNING_CHECK_INTERVAL >= 1) {
 
-            int elapsedSeconds = (ticksSinceLastAction - planningStartTick) / 20;
-            if (elapsedSeconds >= SteveConfig.PLANNING_TIMEOUT_SECONDS.get()) {
-                SteveMod.LOGGER.warn("Steve '{}' planning timed out after {}s", steve.getSteveName(), elapsedSeconds);
-                AgentDebugBuffer.log(steve.getSteveName(), "PLAN", "planning timed out after " + elapsedSeconds + "s");
+                int elapsedSeconds = (ticksSinceLastAction - planningStartTick) / 20;
+                if (elapsedSeconds >= SteveConfig.PLANNING_TIMEOUT_SECONDS.get()) {
+                    SteveMod.LOGGER.warn("Steve '{}' planning timed out after {}s", steve.getSteveName(), elapsedSeconds);
+                    AgentDebugBuffer.log(steve.getSteveName(), "PLAN", "planning timed out after " + elapsedSeconds + "s");
 
-                if (planningFuture != null) {
-                    planningFuture.cancel(true);
+                    if (planningFuture != null) {
+                        planningFuture.cancel(true);
+                    }
+
+                    sendToGUI(steve.getSteveName(), "LLM planning timed out — please try again.");
+                    isPlanning = false;
+                    planningFuture = null;
+                    pendingCommand = null;
+                    planningStartTick = -1;
                 }
-
-                sendToGUI(steve.getSteveName(), "LLM planning timed out — please try again.");
-                isPlanning = false;
-                planningFuture = null;
-                pendingCommand = null;
-                planningStartTick = -1;
             }
         }
 
@@ -474,19 +501,21 @@ public class ActionExecutor {
      * stop/stay commands abort planning as well as execution.
      */
     private void cancelPlanning() {
-        if (isPlanning || planningFuture != null) {
-            if (planningFuture != null) {
-                planningFuture.cancel(true);
+        synchronized (planningLock) {
+            if (isPlanning || planningFuture != null) {
+                if (planningFuture != null) {
+                    planningFuture.cancel(true);
+                }
+                SteveMod.LOGGER.info("Steve '{}' planning cancelled by stop", steve.getSteveName());
+                AgentDebugBuffer.log(steve.getSteveName(), "PLAN", "planning cancelled by stop command");
+                if (steve.level().isClientSide()) {
+                    sendToGUI(steve.getSteveName(), "Planning cancelled.");
+                }
+                isPlanning = false;
+                planningFuture = null;
+                pendingCommand = null;
+                planningStartTick = -1;
             }
-            SteveMod.LOGGER.info("Steve '{}' planning cancelled by stop", steve.getSteveName());
-            AgentDebugBuffer.log(steve.getSteveName(), "PLAN", "planning cancelled by stop command");
-            if (steve.level().isClientSide()) {
-                sendToGUI(steve.getSteveName(), "Planning cancelled.");
-            }
-            isPlanning = false;
-            planningFuture = null;
-            pendingCommand = null;
-            planningStartTick = -1;
         }
     }
 
@@ -556,7 +585,9 @@ public class ActionExecutor {
      * @return true if planning
      */
     public boolean isPlanning() {
-        return isPlanning;
+        synchronized (planningLock) {
+            return isPlanning;
+        }
     }
 
     /**
@@ -564,10 +595,12 @@ public class ActionExecutor {
      * Package-private so unit tests in the same package can set up a stuck-planning scenario.
      */
     void setPlanningFutureForTest(CompletableFuture<ResponseParser.ParsedResponse> future, String command) {
-        this.pendingCommand = command;
-        this.isPlanning = true;
-        this.planningFuture = future;
-        this.planningStartTick = this.ticksSinceLastAction;
+        synchronized (planningLock) {
+            this.pendingCommand = command;
+            this.isPlanning = true;
+            this.planningFuture = future;
+            this.planningStartTick = this.ticksSinceLastAction;
+        }
     }
 
     /**
@@ -588,8 +621,16 @@ public class ActionExecutor {
      * One-line summary of the agent state, used by /steve debug.
      */
     public String getStateSummary() {
-        if (isPlanning) {
-            return "planning (" + (pendingCommand != null ? truncate(pendingCommand, 50) : "?") + ")";
+        String summary;
+        synchronized (planningLock) {
+            if (isPlanning) {
+                summary = "planning (" + (pendingCommand != null ? truncate(pendingCommand, 50) : "?") + ")";
+            } else {
+                summary = null;
+            }
+        }
+        if (summary != null) {
+            return summary;
         }
         if (currentAction != null) {
             return "executing: " + truncate(currentAction.getDescription(), 60)

--- a/src/test/java/com/steve/ai/action/ActionExecutorTest.java
+++ b/src/test/java/com/steve/ai/action/ActionExecutorTest.java
@@ -58,4 +58,33 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         assertFalse(executor.isPlanning(), "Planning flag should be reset after timeout");
         assertTrue(never.isCancelled(), "Stuck future should be cancelled by watchdog");
     }
+
+    @Test
+    void stopCurrentActionCancelsPlanning() {
+        // Given a Steve whose level reports not client-side
+        SteveEntity steve = mock(SteveEntity.class);
+        Level level = mock(Level.class);
+        PathNavigation navigation = mock(PathNavigation.class);
+
+        when(level.isClientSide()).thenReturn(false);
+        when(level.players()).thenReturn(Collections.emptyList());
+        when(steve.level()).thenReturn(level);
+        when(steve.getSteveName()).thenReturn("TestSteve");
+        when(steve.getNavigation()).thenReturn(navigation);
+
+        ActionExecutor executor = new ActionExecutor(steve);
+
+        // Start an async planning future that would never complete
+        CompletableFuture<ResponseParser.ParsedResponse> never = new CompletableFuture<>();
+        executor.setPlanningFutureForTest(never, "chop 5 wood");
+
+        assertTrue(executor.isPlanning(), "Steve should be planning before stop");
+
+        // When stopCurrentAction is called (triggered by /steve stop or stay)
+        executor.stopCurrentAction();
+
+        // Then planning is cancelled and state is reset
+        assertFalse(executor.isPlanning(), "Planning flag should be reset after stop");
+        assertTrue(never.isCancelled(), "Planning future should be cancelled by stop");
+    }
 }

--- a/src/test/java/com/steve/ai/action/ActionExecutorTest.java
+++ b/src/test/java/com/steve/ai/action/ActionExecutorTest.java
@@ -3,6 +3,7 @@ package com.steve.ai.action;
 import com.steve.ai.config.SteveConfig;
 import com.steve.ai.entity.SteveEntity;
 import com.steve.ai.llm.ResponseParser;
+import com.steve.ai.memory.SteveMemory;
 import com.steve.ai.testutil.AbstractMinecraftTest;
 import com.electronwill.nightconfig.core.CommentedConfig;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
@@ -11,8 +12,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -35,12 +42,14 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         SteveEntity steve = mock(SteveEntity.class);
         Level level = mock(Level.class);
         PathNavigation navigation = mock(PathNavigation.class);
+        SteveMemory memory = mock(SteveMemory.class);
 
         when(level.isClientSide()).thenReturn(false);
         when(level.players()).thenReturn(Collections.emptyList());
         when(steve.level()).thenReturn(level);
         when(steve.getSteveName()).thenReturn("TestSteve");
         when(steve.getNavigation()).thenReturn(navigation);
+        when(steve.getMemory()).thenReturn(memory);
 
         ActionExecutor executor = new ActionExecutor(steve);
 
@@ -66,12 +75,14 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         SteveEntity steve = mock(SteveEntity.class);
         Level level = mock(Level.class);
         PathNavigation navigation = mock(PathNavigation.class);
+        SteveMemory memory = mock(SteveMemory.class);
 
         when(level.isClientSide()).thenReturn(false);
         when(level.players()).thenReturn(Collections.emptyList());
         when(steve.level()).thenReturn(level);
         when(steve.getSteveName()).thenReturn("TestSteve");
         when(steve.getNavigation()).thenReturn(navigation);
+        when(steve.getMemory()).thenReturn(memory);
 
         ActionExecutor executor = new ActionExecutor(steve);
 
@@ -95,12 +106,14 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         SteveEntity steve = mock(SteveEntity.class);
         Level level = mock(Level.class);
         PathNavigation navigation = mock(PathNavigation.class);
+        SteveMemory memory = mock(SteveMemory.class);
 
         when(level.isClientSide()).thenReturn(false);
         when(level.players()).thenReturn(Collections.emptyList());
         when(steve.level()).thenReturn(level);
         when(steve.getSteveName()).thenReturn("TestSteve");
         when(steve.getNavigation()).thenReturn(navigation);
+        when(steve.getMemory()).thenReturn(memory);
 
         ActionExecutor executor = new ActionExecutor(steve);
 
@@ -131,5 +144,116 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         // Then planning state is cleanly reset and the future is cancelled
         assertFalse(executor.isPlanning(), "Planning flag should be reset after concurrent stop");
         assertTrue(blockingFuture.isCancelled(), "Planning future should be cancelled by concurrent stop");
+    }
+
+    /**
+     * Future that blocks tick() inside {@link Future#get()} until the test releases it.
+     * Used to simulate the stop-then-start race where a result from the first planning
+     * request arrives after a second request already owns the planning state.
+     */
+    private static class BarrierFuture implements Future<ResponseParser.ParsedResponse> {
+        private final ResponseParser.ParsedResponse response;
+        private final CountDownLatch entered;
+        private final CountDownLatch release;
+        private volatile boolean cancelled = false;
+
+        BarrierFuture(ResponseParser.ParsedResponse response, CountDownLatch entered, CountDownLatch release) {
+            this.response = response;
+            this.entered = entered;
+            this.release = release;
+        }
+
+        @Override
+        public boolean isDone() {
+            return true;
+        }
+
+        @Override
+        public ResponseParser.ParsedResponse get() throws InterruptedException, ExecutionException {
+            entered.countDown();
+            release.await();
+            return response;
+        }
+
+        @Override
+        public ResponseParser.ParsedResponse get(long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            entered.countDown();
+            if (!release.await(timeout, unit)) {
+                throw new TimeoutException();
+            }
+            return response;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            cancelled = true;
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+    }
+
+    @Test
+    void stalePlanningResultIsDiscardedAfterStopThenStart() throws InterruptedException {
+        // Given a Steve whose level reports not client-side
+        SteveEntity steve = mock(SteveEntity.class);
+        Level level = mock(Level.class);
+        PathNavigation navigation = mock(PathNavigation.class);
+        SteveMemory memory = mock(SteveMemory.class);
+
+        when(level.isClientSide()).thenReturn(false);
+        when(level.players()).thenReturn(Collections.emptyList());
+        when(steve.level()).thenReturn(level);
+        when(steve.getSteveName()).thenReturn("TestSteve");
+        when(steve.getNavigation()).thenReturn(navigation);
+        when(steve.getMemory()).thenReturn(memory);
+
+        ActionExecutor executor = new ActionExecutor(steve);
+
+        // Build two different planning responses
+        ResponseParser.ParsedResponse response1 = new ResponseParser.ParsedResponse(
+            "first", "gather wood", List.of(new Task("gather", Map.of("resource", "wood", "quantity", 5))));
+        ResponseParser.ParsedResponse response2 = new ResponseParser.ParsedResponse(
+            "second", "mine stone", List.of(new Task("mine", Map.of("block", "stone", "quantity", 3))));
+
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        BarrierFuture future1 = new BarrierFuture(response1, entered, release);
+
+        // Inject the first (slow) planning future
+        executor.setPlanningFutureForTest(future1, "cmd1");
+        assertTrue(executor.isPlanning(), "Steve should be planning before tick");
+
+        // Start tick() on another thread; it will block inside future1.get()
+        Thread tickThread = new Thread(executor::tick);
+        tickThread.start();
+
+        // Wait until tick() has entered Future.get()
+        entered.await();
+
+        // Simulate stop-then-start: cancel the first request and start a second one
+        executor.stopCurrentAction();
+        assertTrue(future1.isCancelled(), "BarrierFuture.cancel should record cancellation");
+        CompletableFuture<ResponseParser.ParsedResponse> future2 = CompletableFuture.completedFuture(response2);
+        executor.setPlanningFutureForTest(future2, "cmd2");
+
+        // Release the barrier so the first tick() can return from get() and re-check request ID
+        release.countDown();
+        tickThread.join();
+
+        // Then the stale first response must NOT have been applied
+        assertNull(executor.getCurrentGoal(), "Stale plan should not be the current goal");
+        assertNotEquals("gather wood", executor.getCurrentGoal(), "Stale plan must not be applied");
+        assertTrue(executor.isPlanning(), "Second request should still be planning");
+
+        // When tick() runs again it applies the second response
+        executor.tick();
+
+        assertEquals("mine stone", executor.getCurrentGoal(), "Second plan should be applied");
+        assertTrue(executor.getQueuedTaskCount() > 0, "Second plan tasks should be queued");
     }
 }

--- a/src/test/java/com/steve/ai/action/ActionExecutorTest.java
+++ b/src/test/java/com/steve/ai/action/ActionExecutorTest.java
@@ -122,10 +122,11 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         Thread worker = new Thread(executor::stopCurrentAction);
         worker.start();
 
-        // Let the threads race, then release the planning future and wait for the worker
-        Thread.sleep(50);
-        latch.countDown();
+        // Wait for stopCurrentAction() to cancel the future before releasing the latch,
+        // otherwise the async planning task may complete naturally and bypass the
+        // cancellation path.
         worker.join();
+        latch.countDown();
 
         // Then planning state is cleanly reset and the future is cancelled
         assertFalse(executor.isPlanning(), "Planning flag should be reset after concurrent stop");

--- a/src/test/java/com/steve/ai/action/ActionExecutorTest.java
+++ b/src/test/java/com/steve/ai/action/ActionExecutorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -86,5 +87,48 @@ class ActionExecutorTest extends AbstractMinecraftTest {
         // Then planning is cancelled and state is reset
         assertFalse(executor.isPlanning(), "Planning flag should be reset after stop");
         assertTrue(never.isCancelled(), "Planning future should be cancelled by stop");
+    }
+
+    @Test
+    void concurrentStopDuringPlanningDoesNotCorruptState() throws InterruptedException {
+        // Given a Steve whose level reports not client-side
+        SteveEntity steve = mock(SteveEntity.class);
+        Level level = mock(Level.class);
+        PathNavigation navigation = mock(PathNavigation.class);
+
+        when(level.isClientSide()).thenReturn(false);
+        when(level.players()).thenReturn(Collections.emptyList());
+        when(steve.level()).thenReturn(level);
+        when(steve.getSteveName()).thenReturn("TestSteve");
+        when(steve.getNavigation()).thenReturn(navigation);
+
+        ActionExecutor executor = new ActionExecutor(steve);
+
+        // Start a planning future that blocks until we release the latch
+        CountDownLatch latch = new CountDownLatch(1);
+        CompletableFuture<ResponseParser.ParsedResponse> blockingFuture = CompletableFuture.supplyAsync(() -> {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        });
+
+        executor.setPlanningFutureForTest(blockingFuture, "chop 5 wood");
+        assertTrue(executor.isPlanning(), "Steve should be planning before stop");
+
+        // When stopCurrentAction is called from a worker thread while planning is active
+        Thread worker = new Thread(executor::stopCurrentAction);
+        worker.start();
+
+        // Let the threads race, then release the planning future and wait for the worker
+        Thread.sleep(50);
+        latch.countDown();
+        worker.join();
+
+        // Then planning state is cleanly reset and the future is cancelled
+        assertFalse(executor.isPlanning(), "Planning flag should be reset after concurrent stop");
+        assertTrue(blockingFuture.isCancelled(), "Planning future should be cancelled by concurrent stop");
     }
 }


### PR DESCRIPTION
Fixes #5

## Problem
`stop`/`stay` commands did not cancel an in-flight async LLM planning request, leaving the bot stuck in `isPlanning=true` until the 75s planning watchdog expired.

## Changes
- Added `ActionExecutor.cancelPlanning()` that cancels `planningFuture`, resets planning state, and logs the event.
- Wired it into `stopCurrentAction()` so `/steve stop` and the stay pre-trigger both abort planning immediately.
- Added regression test `stopCurrentActionCancelsPlanning()`.

## Verification
- `nice -n 19 ionice -c3 ./gradlew compileJava compileTestJava --no-daemon -Dorg.gradle.jvmargs="-Xmx768m" --max-workers=1` — BUILD SUCCESSFUL
- `nice -n 19 ionice -c3 ./gradlew test --tests com.steve.ai.action.ActionExecutorTest --no-daemon -Dorg.gradle.jvmargs="-Xmx768m" --max-workers=1` — 2 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Исправления**
  - Повышена надёжность асинхронного планирования действий при одновременной остановке и выполнении задач.
  - Остановка текущего действия теперь атомарно отменяет незавершённое планирование и очищает его состояние.
  - При ошибках запуска корректно сбрасываются связанные данные, предотвращая зависшее или некорректное состояние.
  - Улучшена обработка завершённых и отменённых задач, включая ситуации с тайм-аутами и конкурентными операциями.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->