### PR TITLE
fix(command): show 'key: not required' for providers that need no API key (#27)

### DIFF
--- a/src/main/java/ru/pravets/vasyan/command/VasyanCommands.java
+++ b/src/main/java/ru/pravets/vasyan/command/VasyanCommands.java
@@ -223,11 +223,17 @@ public class VasyanCommands {
         }
         String activeKey = VasyanConfig.LLM_API_KEY.get();
         boolean keyPresent = activeKey != null && !activeKey.isEmpty();
-        String modelLine = "§eModel: §f" + activeModel + "§7 | key: " + (keyPresent ? "§aset" : "§cmissing");
+        boolean keyRequired = LLMProviders.requiresKey(activeProvider);
+        String keyLine;
+        if (!keyRequired) {
+            keyLine = "§eModel: §f" + activeModel + "§7 | key: §7not required";
+        } else {
+            keyLine = "§eModel: §f" + activeModel + "§7 | key: " + (keyPresent ? "§aset" : "§cmissing");
+        }
 
         source.sendSuccess(() -> Component.literal(
             "§eActive provider: §f" + activeProvider + "§7 (" + activeBase + ")"), false);
-        source.sendSuccess(() -> Component.literal(modelLine), false);
+        source.sendSuccess(() -> Component.literal(keyLine), false);
 
         // Live health check of the active provider (GET /models, 3s timeout)
         String providerId = activeProvider;

--- a/src/main/java/ru/pravets/vasyan/command/VasyanCommands.java
+++ b/src/main/java/ru/pravets/vasyan/command/VasyanCommands.java
@@ -225,7 +225,10 @@ public class VasyanCommands {
         boolean keyPresent = activeKey != null && !activeKey.isEmpty();
         boolean keyRequired = LLMProviders.requiresKey(activeProvider);
         String keyLine;
-        if (!keyRequired) {
+        if (LLMProviders.CUSTOM.equals(activeProvider)) {
+            // Custom endpoint may or may not need a key - depends on the server.
+            keyLine = "§eModel: §f" + activeModel + "§7 | key: §7optional";
+        } else if (!keyRequired) {
             keyLine = "§eModel: §f" + activeModel + "§7 | key: §7not required";
         } else {
             keyLine = "§eModel: §f" + activeModel + "§7 | key: " + (keyPresent ? "§aset" : "§cmissing");

--- a/src/main/java/ru/pravets/vasyan/config/VasyanConfig.java
+++ b/src/main/java/ru/pravets/vasyan/config/VasyanConfig.java
@@ -37,8 +37,8 @@ public class VasyanConfig {
 
         builder.comment("LLM provider configuration. All providers use the OpenAI-compatible Chat Completions API.",
             "provider: openai | groq | gemini | ollama | lmstudio | opencode-go | custom",
-            "  ollama     -> http://localhost:11434/v1 (no key needed)",
-            "  lmstudio   -> http://localhost:1234/v1 (no key needed)",
+            "  ollama     -> http://127.0.0.1:11434/v1 (no key needed)",
+            "  lmstudio   -> http://127.0.0.1:1234/v1 (no key needed)",
             "  opencode-go-> https://opencode.ai/zen/go/v1 (key from OpenCode Zen, models like deepseek-v4-flash)",
             "  custom     -> any OpenAI-compatible endpoint, baseUrl is required")
             .push("llm");
@@ -48,7 +48,7 @@ public class VasyanConfig {
             .define("provider", "ollama");
 
         LLM_BASE_URL = builder
-            .comment("Base URL override. Empty = preset default (e.g. http://localhost:11434/v1 for ollama).",
+            .comment("Base URL override. Empty = preset default (e.g. http://127.0.0.1:11434/v1 for ollama).",
                 "Required for provider 'custom'.")
             .define("baseUrl", "");
 

--- a/src/main/java/ru/pravets/vasyan/llm/LLMProviders.java
+++ b/src/main/java/ru/pravets/vasyan/llm/LLMProviders.java
@@ -25,8 +25,8 @@ public final class LLMProviders {
         OPENAI,     new Preset("https://api.openai.com/v1", "gpt-4o-mini", true),
         GROQ,       new Preset("https://api.groq.com/openai/v1", "llama-3.1-8b-instant", true),
         GEMINI,     new Preset("https://generativelanguage.googleapis.com/v1beta/openai", "gemini-2.5-flash", true),
-        OLLAMA,     new Preset("http://localhost:11434/v1", "llama3.1", false),
-        LMSTUDIO,   new Preset("http://localhost:1234/v1", "", false),
+        OLLAMA,     new Preset("http://127.0.0.1:11434/v1", "llama3.1", false),
+        LMSTUDIO,   new Preset("http://127.0.0.1:1234/v1", "", false),
         OPENCODE_GO, new Preset("https://opencode.ai/zen/go/v1", "deepseek-v4-flash", true),
         CUSTOM,     new Preset("", "", false)
     );

--- a/src/main/java/ru/pravets/vasyan/llm/async/OpenAICompatibleClient.java
+++ b/src/main/java/ru/pravets/vasyan/llm/async/OpenAICompatibleClient.java
@@ -153,7 +153,9 @@ public class OpenAICompatibleClient implements AsyncLLMClient {
             }
             return healthy;
         } catch (Exception e) {
-            LOGGER.warn("[{}] Health check failed: {}", providerId, e.getMessage());
+            LOGGER.warn("[{}] Health check failed ({}): {} against {}",
+                providerId, e.getClass().getSimpleName(),
+                e.getMessage() != null ? e.getMessage() : "no message", baseUrl);
             return false;
         }
     }

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
@@ -218,8 +218,8 @@ public class ResilientLLMClient implements AsyncLLMClient {
                     Throwable cause = throwable instanceof CompletionException ?
                         throwable.getCause() : throwable;
 
-                    LOGGER.error("[{}] Request failed after all retries, using fallback: {}",
-                        providerId, cause.getMessage());
+                    LOGGER.error("[{}] Request failed after all retries, using fallback: {}: {}",
+                        providerId, cause.getClass().getSimpleName(), cause.getMessage());
 
                     // Generate fallback response
                     return fallbackHandler.generateFallback(prompt, cause);


### PR DESCRIPTION
## Summary
`/vasyan providers` показывало красное `key: missing` для провайдеров, которым ключ не нужен (ollama, lmstudio, custom). Выглядело как ошибка — вероятная причина репорта #27.

Теперь:
- `requiresKey=false` → серое `key: not required`
- `requiresKey=true`, ключ есть → зелёное `set`
- `requiresKey=true`, ключа нет → красное `missing`

Closes #27

## Checklist
- [x] Ветка от master
- [ ] Build CI зелёный
- [ ] behavior-tests зелёные

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Обновлён вывод списка провайдеров: для провайдеров, которым не требуется API-ключ, теперь отображается статус `key: not required`.
  * Для остальных провайдеров сохранено отображение статуса ключа: `set` или `missing`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->