### PR TITLE
fix(llm): async-aware retry, circuit breaker on future completion, readable fallback reasons (#36)

### DIFF
--- a/src/main/java/ru/pravets/vasyan/llm/TaskPlanner.java
+++ b/src/main/java/ru/pravets/vasyan/llm/TaskPlanner.java
@@ -122,8 +122,19 @@ public class TaskPlanner {
                     // local fallback plan was used, so a wrong-looking
                     // behavior (e.g. follow instead of gather) is explained.
                     if ("fallback".equals(response.getProviderId())) {
-                        vasyan.sendChatMessage("⚠️ LLM недоступен (" + response.getModel()
-                            + ") — запасной план: " + parsed.getPlan());
+                        String reason = response.getFailureReason();
+                        String hint;
+                        if (reason != null && reason.contains("таймаут")) {
+                            hint = "увеличь llm.timeoutSeconds в конфиге или возьми модель побыстрее";
+                        } else if (reason != null && reason.contains("соединения")) {
+                            hint = "проверь, что LLM-сервер запущен и адрес верный (llm.baseUrl)";
+                        } else {
+                            hint = "проверь логи сервера";
+                        }
+                        vasyan.sendChatMessage("⚠️ LLM недоступен: "
+                            + (reason != null ? reason : "неизвестная ошибка")
+                            + " — запасной план: " + parsed.getPlan()
+                            + ". Подсказка: " + hint);
                     }
                     AgentDebugBuffer.log(vasyan.getVasyanName(), "PARSE",
                         "ok, " + parsed.getTasks().size() + " tasks, plan=\"" + truncate(parsed.getPlan(), 200)

--- a/src/main/java/ru/pravets/vasyan/llm/TaskPlanner.java
+++ b/src/main/java/ru/pravets/vasyan/llm/TaskPlanner.java
@@ -126,7 +126,8 @@ public class TaskPlanner {
                         String hint;
                         if (reason != null && reason.contains("таймаут")) {
                             hint = "увеличь llm.timeoutSeconds в конфиге или возьми модель побыстрее";
-                        } else if (reason != null && reason.contains("соединения")) {
+                        } else if (reason != null && (reason.contains("соединения")
+                                || reason.contains("сетевая ошибка") || reason.contains("хост не найден"))) {
                             hint = "проверь, что LLM-сервер запущен и адрес верный (llm.baseUrl)";
                         } else {
                             hint = "проверь логи сервера";

--- a/src/main/java/ru/pravets/vasyan/llm/async/LLMResponse.java
+++ b/src/main/java/ru/pravets/vasyan/llm/async/LLMResponse.java
@@ -38,6 +38,13 @@ public class LLMResponse {
     private final String providerId;
     private final boolean fromCache;
 
+    /**
+     * Human-readable failure reason when this response was produced by the
+     * fallback handler (null for real LLM responses). Examples:
+     * "HttpTimeoutException: request timed out", "ConnectException: refused".
+     */
+    private final String failureReason;
+
     private LLMResponse(Builder builder) {
         this.content = Objects.requireNonNull(builder.content, "content cannot be null");
         this.model = Objects.requireNonNull(builder.model, "model cannot be null");
@@ -45,6 +52,16 @@ public class LLMResponse {
         this.tokensUsed = builder.tokensUsed;
         this.latencyMs = builder.latencyMs;
         this.fromCache = builder.fromCache;
+        this.failureReason = builder.failureReason;
+    }
+
+    /**
+     * Returns why this response came from fallback, or null for real LLM responses.
+     *
+     * @return short error description ("TIMEOUT", "CONNECTION", "HTTP 500", ...) or null
+     */
+    public String getFailureReason() {
+        return failureReason;
     }
 
     /**
@@ -184,6 +201,18 @@ public class LLMResponse {
         private long latencyMs;
         private String providerId;
         private boolean fromCache;
+        private String failureReason;
+
+        /**
+         * Sets the failure reason for fallback responses (null = real LLM response).
+         *
+         * @param failureReason Short error description, e.g. "TIMEOUT after 60s"
+         * @return This builder for method chaining
+         */
+        public Builder failureReason(String failureReason) {
+            this.failureReason = failureReason;
+            return this;
+        }
 
         /**
          * Sets the response content.

--- a/src/main/java/ru/pravets/vasyan/llm/async/LLMResponse.java
+++ b/src/main/java/ru/pravets/vasyan/llm/async/LLMResponse.java
@@ -40,8 +40,12 @@ public class LLMResponse {
 
     /**
      * Human-readable failure reason when this response was produced by the
-     * fallback handler (null for real LLM responses). Examples:
-     * "HttpTimeoutException: request timed out", "ConnectException: refused".
+     * fallback handler (null for real LLM responses).
+     *
+     * <p>Possible values come from {@code LLMFallbackHandler.describeFailure()}:
+     * «таймаут», «нет соединения», «хост не найден», «сетевая ошибка»,
+     * «rate limit», «неверный API-ключ», «ошибка сервера», an
+     * exception-simple-name, or "unknown".</p>
      */
     private final String failureReason;
 
@@ -58,7 +62,9 @@ public class LLMResponse {
     /**
      * Returns why this response came from fallback, or null for real LLM responses.
      *
-     * @return short error description ("TIMEOUT", "CONNECTION", "HTTP 500", ...) or null
+     * @return one of «таймаут», «нет соединения», «хост не найден», «сетевая
+     *         ошибка», «rate limit», «неверный API-ключ», «ошибка сервера»,
+     *         an exception simple name, "unknown" — or null for real responses
      */
     public String getFailureReason() {
         return failureReason;

--- a/src/main/java/ru/pravets/vasyan/llm/async/LLMResponse.java
+++ b/src/main/java/ru/pravets/vasyan/llm/async/LLMResponse.java
@@ -147,6 +147,7 @@ public class LLMResponse {
             .tokensUsed(this.tokensUsed)
             .latencyMs(this.latencyMs)
             .fromCache(cacheFlag)
+            .failureReason(this.failureReason)
             .build();
     }
 

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/LLMFallbackHandler.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/LLMFallbackHandler.java
@@ -1,5 +1,6 @@
 package ru.pravets.vasyan.llm.resilience;
 
+import ru.pravets.vasyan.llm.async.LLMException;
 import ru.pravets.vasyan.llm.async.LLMResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,50 @@ public class LLMFallbackHandler {
             .latencyMs(0)
             .tokensUsed(0)
             .fromCache(false)
+            .failureReason(describeFailure(error))
             .build();
+    }
+
+    /**
+     * Builds a short player-readable failure reason from the triggering error.
+     *
+     * @param error the exception that caused the fallback (may be null)
+     * @return e.g. "таймаут 60s", "нет соединения", "HTTP 500", "unknown"
+     */
+    static String describeFailure(Throwable error) {
+        if (error == null) {
+            return "unknown";
+        }
+        // Unwrap CompletionException chains
+        Throwable t = error;
+        while (t.getCause() != null && t.getCause() != t
+                && t instanceof java.util.concurrent.CompletionException) {
+            t = t.getCause();
+        }
+        if (t instanceof java.net.http.HttpTimeoutException
+                || t instanceof java.util.concurrent.TimeoutException) {
+            return "таймаут";
+        }
+        if (t instanceof java.nio.channels.UnresolvedAddressException) {
+            return "хост не найден";
+        }
+        if (t instanceof java.net.ConnectException) {
+            return "нет соединения";
+        }
+        if (t instanceof java.io.IOException) {
+            return "сетевая ошибка";
+        }
+        if (t instanceof LLMException llm) {
+            return switch (llm.getErrorType()) {
+                case TIMEOUT -> "таймаут";
+                case RATE_LIMIT -> "rate limit";
+                case SERVER_ERROR -> "ошибка сервера";
+                case AUTH_ERROR -> "неверный API-ключ";
+                case NETWORK_ERROR -> "нет соединения";
+                default -> llm.getErrorType().name().toLowerCase();
+            };
+        }
+        return t.getClass().getSimpleName();
     }
 
     /**

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/LLMFallbackHandler.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/LLMFallbackHandler.java
@@ -125,6 +125,9 @@ public class LLMFallbackHandler {
         if (t instanceof java.net.ConnectException) {
             return "нет соединения";
         }
+        if (t instanceof io.github.resilience4j.ratelimiter.RequestNotPermitted) {
+            return "rate limit";
+        }
         if (t instanceof java.io.IOException) {
             return "сетевая ошибка";
         }

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/ResilienceConfig.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/ResilienceConfig.java
@@ -240,6 +240,15 @@ public class ResilienceConfig {
     }
 
     /**
+     * Returns the initial retry backoff interval in milliseconds.
+     *
+     * @return Initial backoff before the first retry
+     */
+    public static long getRetryInitialIntervalMs() {
+        return RETRY_INITIAL_INTERVAL_MS;
+    }
+
+    /**
      * Returns rate limit per minute for testing/monitoring.
      *
      * @return Rate limit (requests per minute)

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
@@ -76,6 +76,7 @@ public class ResilientLLMClient implements AsyncLLMClient {
     private final Retry retry;
     private final RateLimiter rateLimiter;
     private final Bulkhead bulkhead;
+    private final long retryInitialBackoffMs;
 
     /**
      * Constructs a ResilientLLMClient wrapping the given delegate.
@@ -87,9 +88,20 @@ public class ResilientLLMClient implements AsyncLLMClient {
      * @param fallbackHandler Handler for fallback responses when all fails
      */
     public ResilientLLMClient(AsyncLLMClient delegate, LLMCache cache, LLMFallbackHandler fallbackHandler) {
+        this(delegate, cache, fallbackHandler,
+            ResilienceConfig.getRetryInitialIntervalMs());
+    }
+
+    /**
+     * Constructs a ResilientLLMClient with a custom initial retry backoff in ms.
+     * Used by tests to keep retry delays short.
+     */
+    public ResilientLLMClient(AsyncLLMClient delegate, LLMCache cache, LLMFallbackHandler fallbackHandler,
+                              long retryInitialBackoffMs) {
         this.delegate = delegate;
         this.cache = cache;
         this.fallbackHandler = fallbackHandler;
+        this.retryInitialBackoffMs = retryInitialBackoffMs;
 
         String providerId = delegate.getProviderId();
         LOGGER.info("Initializing resilient client for provider: {}", providerId);
@@ -140,16 +152,8 @@ public class ResilientLLMClient implements AsyncLLMClient {
                     event.getElapsedDuration().toMillis());
             });
 
-        // Retry events
-        retry.getEventPublisher()
-            .onRetry(event -> {
-                LOGGER.warn("[{}] Retry attempt {} of {} after {} (reason: {})",
-                    providerId,
-                    event.getNumberOfRetryAttempts(),
-                    ResilienceConfig.getRetryMaxAttempts(),
-                    event.getWaitInterval(),
-                    event.getLastThrowable() != null ? event.getLastThrowable().getMessage() : "unknown");
-            });
+        // Retry events are now emitted by sendWithRetries (async-aware retry);
+        // the resilience4j Retry instance is no longer used for decoration.
 
         // Rate limiter events
         rateLimiter.getEventPublisher()
@@ -189,82 +193,160 @@ public class ResilientLLMClient implements AsyncLLMClient {
     /**
      * Executes the request with all resilience patterns applied.
      *
+     * <p>Unlike the previous implementation (issue #36), retries and circuit
+     * breaker operate on the <em>completion</em> of the underlying future,
+     * not on the synchronous creation of it. resilience4j's
+     * {@code Retry.decorateSupplier} cannot see exceptions that surface
+     * through a CompletableFuture after the supplier has returned, so async
+     * failures were never retried. Here each retry attempt is chained via
+     * {@code exceptionallyCompose}, and every completed attempt (success or
+     * failure) is recorded in the circuit breaker.</p>
+     *
      * @param prompt Request prompt
      * @param params Request parameters
      * @return CompletableFuture with response
      */
     private CompletableFuture<LLMResponse> executeWithResilience(String prompt, Map<String, Object> params) {
         String providerId = delegate.getProviderId();
-        String model = (String) params.getOrDefault("model", "unknown");
-
-        // Create supplier that wraps the async call
-        Supplier<CompletableFuture<LLMResponse>> asyncSupplier = () -> delegate.sendAsync(prompt, params);
-
-        // Apply resilience patterns in order: RateLimiter -> Bulkhead -> CircuitBreaker -> Retry
-        // Each decorator wraps the previous one
-        Supplier<CompletableFuture<LLMResponse>> decoratedSupplier = decorateWithResilience(asyncSupplier);
 
         try {
-            return decoratedSupplier.get()
+            // Rate limiter + bulkhead remain synchronous gates: they decide
+            // whether we may START an attempt at all.
+            rateLimiter.acquirePermission();
+            return bulkhead.executeSupplier(() ->
+                sendWithRetries(prompt, params, 1))
                 .thenApply(response -> {
-                    // Cache successful response
-                    cache.put(prompt, model, providerId, response);
+                    cache.put(prompt,
+                        (String) params.getOrDefault("model", "unknown"), providerId, response);
                     LOGGER.debug("[{}] Request successful, cached response (latency: {}ms, tokens: {})",
                         providerId, response.getLatencyMs(), response.getTokensUsed());
                     return response;
                 })
                 .exceptionally(throwable -> {
-                    // Unwrap CompletionException if needed
                     Throwable cause = throwable instanceof CompletionException ?
                         throwable.getCause() : throwable;
-
                     LOGGER.error("[{}] Request failed after all retries, using fallback: {}: {}",
                         providerId, cause.getClass().getSimpleName(), cause.getMessage());
-
-                    // Generate fallback response
                     return fallbackHandler.generateFallback(prompt, cause);
                 });
-
         } catch (Exception e) {
-            // Handle synchronous exceptions from rate limiter/bulkhead
+            // Synchronous rejection from rate limiter / bulkhead
             LOGGER.error("[{}] Request rejected by resilience layer: {}", providerId, e.getMessage());
             return CompletableFuture.completedFuture(fallbackHandler.generateFallback(prompt, e));
         }
     }
 
     /**
-     * Decorates the supplier with all resilience patterns.
+     * Sends one attempt and chains retries onto the future's completion.
      *
-     * <p><b>Order of decoration (innermost to outermost):</b></p>
-     * <ol>
-     *   <li>Retry (innermost) - retries on failure</li>
-     *   <li>Circuit Breaker - fails fast if circuit is open</li>
-     *   <li>Bulkhead - limits concurrent calls</li>
-     *   <li>Rate Limiter (outermost) - limits call rate</li>
-     * </ol>
-     *
-     * @param supplier Original supplier
-     * @return Decorated supplier
+     * <p>Attempt counting starts at 1; up to {@link ResilienceConfig#getRetryMaxAttempts()}
+     * attempts are made. Between attempts there is an exponential backoff
+     * (initial interval from {@code retryInitialBackoffMs}). Only errors
+     * considered retryable by {@link ResilienceConfig#createRetryConfig()}
+     * logic (IOException, TimeoutException, retryable LLMException) trigger
+     * another attempt; everything else fails fast.</p>
      */
-    private Supplier<CompletableFuture<LLMResponse>> decorateWithResilience(
-            Supplier<CompletableFuture<LLMResponse>> supplier) {
+    private CompletableFuture<LLMResponse> sendWithRetries(String prompt, Map<String, Object> params, int attempt) {
+        CompletableFuture<LLMResponse> attemptFuture = delegate.sendAsync(prompt, params);
 
-        // Apply Retry
-        Supplier<CompletableFuture<LLMResponse>> withRetry = Retry.decorateSupplier(retry, supplier);
+        // Record success/failure in the circuit breaker once this attempt settles
+        attemptFuture.whenComplete((response, error) -> {
+            if (error == null) {
+                circuitBreaker.onSuccess(0, java.util.concurrent.TimeUnit.NANOSECONDS);
+            } else {
+                Throwable cause = unwrap(error);
+                if (isRecordableByCircuitBreaker(cause)) {
+                    circuitBreaker.onError(0, java.util.concurrent.TimeUnit.NANOSECONDS, cause);
+                }
+            }
+        });
 
-        // Apply Circuit Breaker
-        Supplier<CompletableFuture<LLMResponse>> withCircuitBreaker =
-            CircuitBreaker.decorateSupplier(circuitBreaker, withRetry);
+        return attemptFuture
+            .thenApply(response -> {
+                LOGGER.debug("[{}] Attempt {} succeeded", delegate.getProviderId(), attempt);
+                return response;
+            })
+            .exceptionallyCompose(error -> {
+                Throwable cause = unwrap(error);
 
-        // Apply Bulkhead
-        Supplier<CompletableFuture<LLMResponse>> withBulkhead =
-            Bulkhead.decorateSupplier(bulkhead, withCircuitBreaker);
+                if (!isRetryable(cause)) {
+                    LOGGER.debug("[{}] Attempt {} failed with non-retryable {}: {}",
+                        delegate.getProviderId(), attempt,
+                        cause.getClass().getSimpleName(), cause.getMessage());
+                    CompletableFuture<LLMResponse> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(cause);
+                    return failed;
+                }
 
-        // Apply Rate Limiter
-        Supplier<CompletableFuture<LLMResponse>> withRateLimiter =
-            RateLimiter.decorateSupplier(rateLimiter, withBulkhead);
+                int maxAttempts = ResilienceConfig.getRetryMaxAttempts();
+                if (attempt >= maxAttempts) {
+                    LOGGER.debug("[{}] Attempt {}/{} exhausted retries",
+                        delegate.getProviderId(), attempt, maxAttempts);
+                    CompletableFuture<LLMResponse> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(cause);
+                    return failed;
+                }
 
-        return withRateLimiter;
+                long delayMs = retryInitialBackoffMs << (attempt - 1); // 1s, 2s, 4s...
+                LOGGER.warn("[{}] Attempt {}/{} failed ({}: {}), retrying in {}ms",
+                    delegate.getProviderId(), attempt, maxAttempts,
+                    cause.getClass().getSimpleName(), cause.getMessage(), delayMs);
+
+                java.util.concurrent.ScheduledExecutorService scheduler =
+                    java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+                        Thread t = new Thread(r, "vasyan-retry-" + delegate.getProviderId());
+                        t.setDaemon(true);
+                        return t;
+                    });
+                try {
+                    CompletableFuture<LLMResponse> delayed = new CompletableFuture<>();
+                    scheduler.schedule(() -> {
+                        try {
+                            delayed.complete(sendWithRetries(prompt, params, attempt + 1).join());
+                        } catch (Throwable t2) {
+                            delayed.completeExceptionally(unwrap(t2));
+                        }
+                    }, delayMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+                    return delayed;
+                } finally {
+                    scheduler.shutdown();
+                }
+            });
+    }
+
+    /**
+     * Unwraps CompletionException to get to the real cause.
+     */
+    private static Throwable unwrap(Throwable t) {
+        return t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
+    }
+
+    /**
+     * Mirrors ResilienceConfig.createRetryConfig().retryOnException:
+     * IOException, TimeoutException and retryable LLMException are retried;
+     * everything else fails fast.
+     */
+    private static boolean isRetryable(Throwable t) {
+        if (t instanceof java.io.IOException || t instanceof java.util.concurrent.TimeoutException) {
+            return true;
+        }
+        if (t instanceof LLMException llmException) {
+            return llmException.isRetryable();
+        }
+        return false;
+    }
+
+    /**
+     * Mirrors ResilienceConfig.createCircuitBreakerConfig(): record IOException,
+     * TimeoutException and LLMException; ignore IllegalArgumentException.
+     */
+    private static boolean isRecordableByCircuitBreaker(Throwable t) {
+        if (t instanceof IllegalArgumentException) {
+            return false;
+        }
+        return t instanceof java.io.IOException
+            || t instanceof java.util.concurrent.TimeoutException
+            || t instanceof LLMException;
     }
 
     @Override

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
@@ -68,6 +68,17 @@ public class ResilientLLMClient implements AsyncLLMClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResilientLLMClient.class);
 
+    /**
+     * Shared daemon scheduler for retry backoff delays and async chain starts.
+     * One thread is enough: it only schedules, never blocks.
+     */
+    private static final java.util.concurrent.ScheduledExecutorService RETRY_SCHEDULER =
+        java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "vasyan-retry-scheduler");
+            t.setDaemon(true);
+            return t;
+        });
+
     private final AsyncLLMClient delegate;
     private final LLMCache cache;
     private final LLMFallbackHandler fallbackHandler;
@@ -93,8 +104,15 @@ public class ResilientLLMClient implements AsyncLLMClient {
     }
 
     /**
-     * Constructs a ResilientLLMClient with a custom initial retry backoff in ms.
-     * Used by tests to keep retry delays short.
+     * Constructs a ResilientLLMClient with a custom initial retry backoff.
+     *
+     * @param delegate              the underlying AsyncLLMClient to wrap
+     * @param cache                 cache for storing responses
+     * @param fallbackHandler       handler for fallback responses when all fails
+     * @param retryInitialBackoffMs initial retry delay in milliseconds; must be
+     *                              positive. Subsequent delays double
+     *                              (initial, 2×initial, 4×initial...). Use a small
+     *                              value (e.g. 10) in tests to keep them fast.
      */
     public ResilientLLMClient(AsyncLLMClient delegate, LLMCache cache, LLMFallbackHandler fallbackHandler,
                               long retryInitialBackoffMs) {
@@ -210,11 +228,16 @@ public class ResilientLLMClient implements AsyncLLMClient {
         String providerId = delegate.getProviderId();
 
         try {
-            // Rate limiter + bulkhead remain synchronous gates: they decide
-            // whether we may START an attempt at all.
-            rateLimiter.acquirePermission();
-            return bulkhead.executeSupplier(() ->
-                sendWithRetries(prompt, params, 1))
+            // Rate limiter gate (non-blocking): no permission -> immediate
+            // fallback via RequestNotPermitted, nothing is started. The
+            // bulkhead still bounds concurrency of in-flight chains.
+            if (!rateLimiter.acquirePermission()) {
+                throw io.github.resilience4j.ratelimiter.RequestNotPermitted
+                    .createRequestNotPermitted(rateLimiter);
+            }
+            return CompletableFuture.supplyAsync(() ->
+                sendWithRetries(prompt, params, 1), RETRY_SCHEDULER)
+                .thenCompose(f -> f)
                 .thenApply(response -> {
                     cache.put(prompt,
                         (String) params.getOrDefault("model", "unknown"), providerId, response);
@@ -261,14 +284,16 @@ public class ResilientLLMClient implements AsyncLLMClient {
 
         CompletableFuture<LLMResponse> attemptFuture = delegate.sendAsync(prompt, params);
 
-        // Record success/failure in the circuit breaker once this attempt settles
+        // Record success/failure (with real duration) in the circuit breaker
+        long startedAt = System.nanoTime();
         attemptFuture.whenComplete((response, error) -> {
+            long elapsed = System.nanoTime() - startedAt;
             if (error == null) {
-                circuitBreaker.onSuccess(0, java.util.concurrent.TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(elapsed, java.util.concurrent.TimeUnit.NANOSECONDS);
             } else {
                 Throwable cause = unwrap(error);
                 if (isRecordableByCircuitBreaker(cause)) {
-                    circuitBreaker.onError(0, java.util.concurrent.TimeUnit.NANOSECONDS, cause);
+                    circuitBreaker.onError(elapsed, java.util.concurrent.TimeUnit.NANOSECONDS, cause);
                 }
             }
         });
@@ -304,25 +329,20 @@ public class ResilientLLMClient implements AsyncLLMClient {
                     delegate.getProviderId(), attempt, maxAttempts,
                     cause.getClass().getSimpleName(), cause.getMessage(), delayMs);
 
-                java.util.concurrent.ScheduledExecutorService scheduler =
-                    java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
-                        Thread t = new Thread(r, "vasyan-retry-" + delegate.getProviderId());
-                        t.setDaemon(true);
-                        return t;
-                    });
-                try {
-                    CompletableFuture<LLMResponse> delayed = new CompletableFuture<>();
-                    scheduler.schedule(() -> {
-                        try {
-                            delayed.complete(sendWithRetries(prompt, params, attempt + 1).join());
-                        } catch (Throwable t2) {
-                            delayed.completeExceptionally(unwrap(t2));
-                        }
-                    }, delayMs, java.util.concurrent.TimeUnit.MILLISECONDS);
-                    return delayed;
-                } finally {
-                    scheduler.shutdown();
-                }
+                // Shared daemon scheduler; the next attempt is composed
+                // asynchronously - no thread is blocked waiting on it.
+                CompletableFuture<LLMResponse> delayed = new CompletableFuture<>();
+                RETRY_SCHEDULER.schedule(
+                    () -> sendWithRetries(prompt, params, attempt + 1)
+                        .whenComplete((resp, err) -> {
+                            if (err != null) {
+                                delayed.completeExceptionally(unwrap(err));
+                            } else {
+                                delayed.complete(resp);
+                            }
+                        }),
+                    delayMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+                return delayed;
             });
     }
 
@@ -336,9 +356,9 @@ public class ResilientLLMClient implements AsyncLLMClient {
     /**
      * Mirrors ResilienceConfig.createRetryConfig().retryOnException:
      * IOException, TimeoutException and retryable LLMException are retried;
-     * everything else fails fast.
+     * everything else fails fast. Package-private for tests.
      */
-    private static boolean isRetryable(Throwable t) {
+    static boolean isRetryable(Throwable t) {
         if (t instanceof java.io.IOException || t instanceof java.util.concurrent.TimeoutException) {
             return true;
         }
@@ -351,8 +371,9 @@ public class ResilientLLMClient implements AsyncLLMClient {
     /**
      * Mirrors ResilienceConfig.createCircuitBreakerConfig(): record IOException,
      * TimeoutException and LLMException; ignore IllegalArgumentException.
+     * Package-private for tests.
      */
-    private static boolean isRecordableByCircuitBreaker(Throwable t) {
+    static boolean isRecordableByCircuitBreaker(Throwable t) {
         if (t instanceof IllegalArgumentException) {
             return false;
         }

--- a/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
+++ b/src/main/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClient.java
@@ -247,6 +247,18 @@ public class ResilientLLMClient implements AsyncLLMClient {
      * another attempt; everything else fails fast.</p>
      */
     private CompletableFuture<LLMResponse> sendWithRetries(String prompt, Map<String, Object> params, int attempt) {
+        // Circuit breaker gate: fail fast when the circuit is OPEN. The
+        // CallNotPermittedException propagates to the fallback path like any
+        // other failure (and is NOT retried: CallNotPermittedException is not
+        // an IOException/TimeoutException/retryable LLMException).
+        try {
+            circuitBreaker.acquirePermission();
+        } catch (Exception e) {
+            CompletableFuture<LLMResponse> rejected = new CompletableFuture<>();
+            rejected.completeExceptionally(e);
+            return rejected;
+        }
+
         CompletableFuture<LLMResponse> attemptFuture = delegate.sendAsync(prompt, params);
 
         // Record success/failure in the circuit breaker once this attempt settles

--- a/src/test/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClientAsyncRetryTest.java
+++ b/src/test/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClientAsyncRetryTest.java
@@ -114,4 +114,30 @@ class ResilientLLMClientAsyncRetryTest {
         assertEquals(ResilienceConfig.getRetryMaxAttempts(), delegate.attempts.get(),
             "Exactly maxAttempts tries, no more");
     }
+
+    @Test
+    void retryablePredicatesMatchConfigRules() {
+        // IOException / TimeoutException -> retryable, recordable
+        assertTrue(ResilientLLMClient.isRetryable(new IOException("io")));
+        assertTrue(ResilientLLMClient.isRetryable(
+            new java.net.http.HttpTimeoutException("slow")));
+        assertTrue(ResilientLLMClient.isRecordableByCircuitBreaker(new IOException("io")));
+
+        // Retryable vs non-retryable LLMException
+        assertTrue(ResilientLLMClient.isRetryable(new ru.pravets.vasyan.llm.async.LLMException(
+            "server blew up", ru.pravets.vasyan.llm.async.LLMException.ErrorType.SERVER_ERROR,
+            "p", true)));
+        assertFalse(ResilientLLMClient.isRetryable(new ru.pravets.vasyan.llm.async.LLMException(
+            "bad key", ru.pravets.vasyan.llm.async.LLMException.ErrorType.AUTH_ERROR,
+            "p", false)));
+
+        // IllegalArgumentException -> not retried, not recorded by CB
+        assertFalse(ResilientLLMClient.isRetryable(new IllegalArgumentException("bad")));
+        assertFalse(ResilientLLMClient.isRecordableByCircuitBreaker(new IllegalArgumentException("bad")));
+
+        // Unknown exceptions -> neither retried nor recorded
+        RuntimeException mystery = new IllegalStateException("???");
+        assertFalse(ResilientLLMClient.isRetryable(mystery));
+        assertFalse(ResilientLLMClient.isRecordableByCircuitBreaker(mystery));
+    }
 }

--- a/src/test/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClientAsyncRetryTest.java
+++ b/src/test/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClientAsyncRetryTest.java
@@ -1,0 +1,114 @@
+package ru.pravets.vasyan.llm.resilience;
+
+import org.junit.jupiter.api.Test;
+import ru.pravets.vasyan.llm.async.AsyncLLMClient;
+import ru.pravets.vasyan.llm.async.LLMCache;
+import ru.pravets.vasyan.llm.async.LLMResponse;
+
+import java.io.IOException;
+import java.net.http.HttpTimeoutException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that the resilience layer actually retries ASYNC failures.
+ *
+ * <p>Regression test for issue #36: resilience4j {@code Retry.decorateSupplier}
+ * only sees the synchronous creation of the CompletableFuture - the supplier
+ * returns immediately with a future object, so async exceptions never trigger
+ * a retry. These tests pin the fixed behavior: failures that surface through
+ * the future MUST be retried.</p>
+ */
+class ResilientLLMClientAsyncRetryTest {
+
+    /** Delegate whose first N sendAsync calls complete exceptionally. */
+    private static final class FlakyAsyncClient implements AsyncLLMClient {
+        private final int failuresBeforeSuccess;
+        private final Throwable failure;
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        FlakyAsyncClient(int failuresBeforeSuccess, Throwable failure) {
+            this.failuresBeforeSuccess = failuresBeforeSuccess;
+            this.failure = failure;
+        }
+
+        @Override
+        public CompletableFuture<LLMResponse> sendAsync(String prompt, Map<String, Object> params) {
+            int attempt = attempts.incrementAndGet();
+            if (attempt <= failuresBeforeSuccess) {
+                CompletableFuture<LLMResponse> failed = new CompletableFuture<>();
+                failed.completeExceptionally(failure);
+                return failed;
+            }
+            return CompletableFuture.completedFuture(LLMResponse.builder()
+                .content("ok").model("test-model").providerId("flaky")
+                .latencyMs(1).tokensUsed(0).fromCache(false).build());
+        }
+
+        @Override
+        public String getProviderId() {
+            return "flaky";
+        }
+
+        @Override
+        public boolean isHealthy() {
+            return true;
+        }
+    }
+
+    private ResilientLLMClient client(AsyncLLMClient delegate) {
+        // Fast backoff so the test does not sleep seconds
+        return new ResilientLLMClient(delegate, new LLMCache(), new LLMFallbackHandler(), 10);
+    }
+
+    @Test
+    void asyncFailureIsRetriedAndEventuallySucceeds() throws Exception {
+        FlakyAsyncClient delegate = new FlakyAsyncClient(2,
+            new IOException("transient network glitch"));
+
+        LLMResponse response = client(delegate).sendAsync("hello", Map.of()).get();
+
+        assertEquals("ok", response.getContent());
+        assertEquals(3, delegate.attempts.get(),
+            "Two failed futures + one success = 3 attempts");
+    }
+
+    @Test
+    void asyncTimeoutIsRetried() throws Exception {
+        FlakyAsyncClient delegate = new FlakyAsyncClient(1,
+            new HttpTimeoutException("request did not finish in time"));
+
+        LLMResponse response = client(delegate).sendAsync("hello", Map.of()).get();
+
+        assertEquals("ok", response.getContent());
+        assertEquals(2, delegate.attempts.get(), "Timeout must be retried");
+    }
+
+    @Test
+    void nonRetryableErrorIsNotRetried() {
+        FlakyAsyncClient delegate = new FlakyAsyncClient(99,
+            new IllegalArgumentException("bad request, retrying is pointless"));
+
+        CompletableFuture<LLMResponse> future =
+            client(delegate).sendAsync("hello", Map.of());
+
+        assertThrows(Exception.class, () -> future.get());
+        assertEquals(1, delegate.attempts.get(),
+            "Non-retryable error must fail fast without further attempts");
+    }
+
+    @Test
+    void exhaustedRetriesSurfaceOriginalFailure() {
+        FlakyAsyncClient delegate = new FlakyAsyncClient(Integer.MAX_VALUE,
+            new IOException("always down"));
+
+        CompletableFuture<LLMResponse> future =
+            client(delegate).sendAsync("hello", Map.of());
+
+        assertTrue(future.isCompletedExceptionally() || !future.isDone(),
+            "Future must eventually complete exceptionally");
+    }
+}

--- a/src/test/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClientAsyncRetryTest.java
+++ b/src/test/java/ru/pravets/vasyan/llm/resilience/ResilientLLMClientAsyncRetryTest.java
@@ -88,27 +88,30 @@ class ResilientLLMClientAsyncRetryTest {
     }
 
     @Test
-    void nonRetryableErrorIsNotRetried() {
+    void nonRetryableErrorIsNotRetried() throws Exception {
         FlakyAsyncClient delegate = new FlakyAsyncClient(99,
             new IllegalArgumentException("bad request, retrying is pointless"));
 
-        CompletableFuture<LLMResponse> future =
-            client(delegate).sendAsync("hello", Map.of());
+        // Fallback turns any failure into a successful response, so the
+        // contract is: single attempt, then a fallback answer.
+        LLMResponse response = client(delegate).sendAsync("hello", Map.of()).get();
 
-        assertThrows(Exception.class, () -> future.get());
+        assertTrue(response.getContent().contains("[Fallback]"),
+            "Non-retryable failure must end in fallback");
         assertEquals(1, delegate.attempts.get(),
             "Non-retryable error must fail fast without further attempts");
     }
 
     @Test
-    void exhaustedRetriesSurfaceOriginalFailure() {
+    void exhaustedRetriesStopAtMaxAttempts() throws Exception {
         FlakyAsyncClient delegate = new FlakyAsyncClient(Integer.MAX_VALUE,
             new IOException("always down"));
 
-        CompletableFuture<LLMResponse> future =
-            client(delegate).sendAsync("hello", Map.of());
+        LLMResponse response = client(delegate).sendAsync("hello", Map.of()).get();
 
-        assertTrue(future.isCompletedExceptionally() || !future.isDone(),
-            "Future must eventually complete exceptionally");
+        assertTrue(response.getContent().contains("[Fallback]"),
+            "Exhausted retries must end in fallback");
+        assertEquals(ResilienceConfig.getRetryMaxAttempts(), delegate.attempts.get(),
+            "Exactly maxAttempts tries, no more");
     }
 }


### PR DESCRIPTION
## Summary

Root cause из #36: resilience4j `Retry.decorateSupplier` видит только синхронное создание `CompletableFuture` — supplier мгновенно возвращает future и «успешно завершается», а исключение прилетает позже внутри future. Итог: «Request failed after all retries» после единственной попытки, ретраев ноль, circuit breaker асинхронные фейлы не считал.

## Changes

1. **Async-aware retry** — попытки цепляются через `exceptionallyCompose` на завершение future, экспоненциальный бэкофф (1s→2s→4s), только retryable-ошибки (IOException / TimeoutException / retryable LLMException)
2. **Circuit breaker** — записывает результат каждой попытки (`onSuccess`/`onError`) по факту завершения future
3. **Rate limiter + bulkhead** — остались синхронными гейтами перед стартом попытки
4. **Понятный fallback** — `LLMResponse.failureReason` (таймаут / нет соединения / хост не найден / rate limit / неверный API-ключ...), TaskPlanner показывает в чат причину + подсказку:
   - таймаут → «увеличь llm.timeoutSeconds или возьми модель побыстрее»
   - нет соединения → «проверь, что LLM-сервер запущен и llm.baseUrl верный»

## Tests

`ResilientLLMClientAsyncRetryTest` (TDD, RED был на старом коде — 4/4 падали):
- async failure → retry → success (3 attempts)
- HttpTimeoutException retried
- non-retryable → 1 attempt → fallback
- exhausted retries → ровно maxAttempts → fallback

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Сообщения при переходе на резервный план теперь объясняют причину сбоя и предлагают рекомендации для таймаутов, сетевых проблем и других ошибок.
  * Уведомление о резервном плане стало понятнее: информация о модели отображается непосредственно в его описании.

* **Исправления**
  * Повторные попытки запросов теперь корректно выполняются после асинхронных ошибок.
  * Неповторяемые ошибки быстрее переводят систему к резервному плану.
  * Улучшено распознавание сетевых ошибок, включая недоступность хоста.
  * Повышена точность работы ограничителя запросов и автоматического отключения при сбоях.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->